### PR TITLE
Support scattered CMS encrypted content from KMS

### DIFF
--- a/source/kms.c
+++ b/source/kms.c
@@ -2201,9 +2201,8 @@ static int s_decrypt_ciphertext_for_recipient(
 
     struct aws_byte_buf encrypted_symm_key, decrypted_symm_key, iv, ciphertext_out;
     int rc = aws_cms_parse_enveloped_data(ciphertext_for_recipient, &encrypted_symm_key, &iv, &ciphertext_out);
-
     if (rc != AWS_OP_SUCCESS) {
-        fprintf(stderr, "Can't parse ciphertext\n");
+        fprintf(stderr, "Cannot parse CMS enveloped data.\n");
         return AWS_OP_ERR;
     }
 
@@ -2216,9 +2215,8 @@ static int s_decrypt_ciphertext_for_recipient(
     }
 
     rc = aws_cms_cipher_decrypt(&ciphertext_out, &decrypted_symm_key, &iv, plaintext);
-
     if (rc != AWS_OP_SUCCESS) {
-        fprintf(stderr, "Can't parse ciphertext\n");
+        fprintf(stderr, "Cannot decrypt CMS encrypted content\n");
         return rc;
     }
 


### PR DESCRIPTION
The RFC does not mention it, but the encryption side
can store the encrypted content into one or more
OCTETSTRINGS, depending on the size. Consume and
gather all of them into one output byte buffer.

Signed-off-by: Alexandru Ciobotaru <alcioa@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
