### PR TITLE
bin: add KMS decrypt example

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 **/.git
 **/target
 **/build
+containers/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,4 +114,7 @@ if (NOT CMAKE_CROSSCOMPILING)
     endif()
 endif()
 
-
+if (NOT CMAKE_CROSSCOMPILING)
+    add_subdirectory(bin/kmstool-enclave)
+    add_subdirectory(bin/kmstool-instance)
+endif()

--- a/bin/kmstool-enclave/CMakeLists.txt
+++ b/bin/kmstool-enclave/CMakeLists.txt
@@ -1,0 +1,25 @@
+project(kmstool-enclave C)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/lib/cmake")
+
+set(KMSTOOL_ENCLAVE_PROJECT_NAME kmstool_enclave)
+add_executable(${KMSTOOL_ENCLAVE_PROJECT_NAME} "main.c")
+
+aws_set_common_properties(${KMSTOOL_ENCLAVE_PROJECT_NAME})
+
+target_include_directories(${KMSTOOL_ENCLAVE_PROJECT_NAME} PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>)
+
+target_link_libraries(${KMSTOOL_ENCLAVE_PROJECT_NAME} aws-nitro-enclaves-sdk-c)
+
+if (BUILD_SHARED_LIBS AND NOT WIN32)
+    message(INFO " kmstool will be built with shared libs, but you may need to set LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib to run the application")
+endif()
+
+install(TARGETS ${KMSTOOL_ENCLAVE_PROJECT_NAME}
+    EXPORT ${KMSTOOL_ENCLAVE_PROJECT_NAME}-targets
+        COMPONENT Runtime
+        RUNTIME
+        DESTINATION bin
+        COMPONENT Runtime)

--- a/bin/kmstool-enclave/main.c
+++ b/bin/kmstool-enclave/main.c
@@ -1,0 +1,411 @@
+#include <aws/nitro_enclaves/kms.h>
+#include <aws/nitro_enclaves/nitro_enclaves.h>
+
+#include <aws/common/command_line_parser.h>
+#include <aws/common/encoding.h>
+#include <aws/common/logging.h>
+
+#include <json-c/json.h>
+
+#include <linux/vm_sockets.h>
+#include <sys/socket.h>
+
+#include <errno.h>
+#include <unistd.h>
+
+#define SERVICE_PORT 3000
+#define PROXY_PORT 2000
+#define BUF_SIZE 8192
+AWS_STATIC_STRING_FROM_LITERAL(default_region, "us-east-1");
+
+enum status {
+    STATUS_OK,
+    STATUS_ERR,
+};
+
+#define fail_on(cond, label, msg)                                                                                      \
+    if (cond) {                                                                                                        \
+        err_msg = NULL;                                                                                                \
+        if (msg != NULL) {                                                                                             \
+            fprintf(stderr, "%s\n", msg);                                                                              \
+            err_msg = msg;                                                                                             \
+        }                                                                                                              \
+        goto label;                                                                                                    \
+    }
+
+#define break_on(cond)                                                                                                 \
+    if (cond) {                                                                                                        \
+        break;                                                                                                         \
+    }
+
+struct app_ctx {
+    /* Allocator to use for memory allocations. */
+    struct aws_allocator *allocator;
+    /* KMS region to use. */
+    const struct aws_string *region;
+    /* vsock port on which to open service. */
+    uint32_t port;
+    /* vsock port on which vsock-proxy is available in parent. */
+    uint32_t proxy_port;
+};
+
+static void s_usage(int exit_code) {
+    fprintf(stderr, "usage: enclave_server [options]\n");
+    fprintf(stderr, "\n Options: \n\n");
+    fprintf(stderr, "    --region REGION: AWS region to use for KMS\n");
+    fprintf(stderr, "    --port PORT: Await new connections on PORT. Default: 3000\n");
+    fprintf(stderr, "    --proxy-port PORT: Connect to KMS proxy on PORT. Default: 2000\n");
+    fprintf(stderr, "    --help: Display this message and exit");
+    exit(exit_code);
+}
+
+static struct aws_cli_option s_long_options[] = {
+    {"region", AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, NULL, 'r'},
+    {"port", AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, NULL, 'p'},
+    {"proxy-port", AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, NULL, 'x'},
+    {"help", AWS_CLI_OPTIONS_NO_ARGUMENT, NULL, 'h'},
+    {NULL, 0, NULL, 0},
+};
+
+static void s_parse_options(int argc, char **argv, struct app_ctx *ctx) {
+    ctx->port = SERVICE_PORT;
+    ctx->proxy_port = PROXY_PORT;
+    ctx->region = default_region;
+
+    while (true) {
+        int option_index = 0;
+        int c = aws_cli_getopt_long(argc, argv, "r:p:x:h", s_long_options, &option_index);
+        if (c == -1) {
+            break;
+        }
+
+        switch (c) {
+            case 0:
+                break;
+            case 'r': {
+                struct aws_byte_cursor cursor = aws_byte_cursor_from_c_str(aws_cli_optarg);
+                ctx->region = aws_string_new_from_cursor(ctx->allocator, &cursor);
+                break;
+            }
+            case 'p':
+                ctx->port = atoi(aws_cli_optarg);
+                break;
+            case 'x':
+                ctx->proxy_port = atoi(aws_cli_optarg);
+                break;
+            case 'h':
+                s_usage(0);
+                break;
+            default:
+                fprintf(stderr, "Unknown option\n");
+                s_usage(1);
+                break;
+        }
+    }
+}
+
+struct aws_credentials *s_read_credentials(struct aws_allocator *allocator, struct json_object *object) {
+    struct aws_credentials *credentials = NULL;
+
+    struct json_object *aws_access_key_id = json_object_object_get(object, "AwsAccessKeyId");
+    struct json_object *aws_secret_access_key = json_object_object_get(object, "AwsSecretAccessKey");
+    struct json_object *aws_session_token = json_object_object_get(object, "AwsSessionToken");
+
+    if (aws_access_key_id == NULL || aws_secret_access_key == NULL ||
+        !json_object_is_type(aws_access_key_id, json_type_string) ||
+        !json_object_is_type(aws_secret_access_key, json_type_string)) {
+        fprintf(stderr, "Error parsing JSON object: credentials not correct");
+        return NULL;
+    }
+
+    if (aws_session_token != NULL && !json_object_is_type(aws_access_key_id, json_type_string)) {
+        fprintf(stderr, "Error parsing JSON object: credentials not correct");
+        return NULL;
+    }
+
+    credentials = aws_credentials_new(
+        allocator,
+        aws_byte_cursor_from_c_str(json_object_get_string(aws_access_key_id)),
+        aws_byte_cursor_from_c_str(json_object_get_string(aws_secret_access_key)),
+        aws_byte_cursor_from_c_str(json_object_get_string(aws_session_token)),
+        UINT64_MAX);
+
+    return credentials;
+}
+
+ssize_t s_write_all(int peer_fd, const char *msg, size_t msg_len) {
+    size_t total_sent = 0;
+    while (total_sent < msg_len) {
+        ssize_t sent = write(peer_fd, msg + total_sent, msg_len - total_sent);
+        if (sent <= 0 && (errno == EAGAIN || errno == EINTR)) {
+            continue;
+        } else if (sent < 0) {
+            return -1;
+        } else {
+            total_sent += sent;
+        }
+    }
+    return total_sent;
+}
+
+int s_send_status(int peer_fd, int status, const char *msg) {
+    struct json_object *status_object = json_object_new_object();
+    if (status_object == NULL) {
+        return -1;
+    }
+
+    json_object_object_add(status_object, "Status", json_object_new_string(status == STATUS_OK ? "Ok" : "Error"));
+
+    if (msg != NULL) {
+        json_object_object_add(status_object, "Message", json_object_new_string(msg));
+    }
+
+    const char *status_str = json_object_to_json_string(status_object);
+    return s_write_all(peer_fd, status_str, strlen(status_str) + 1);
+}
+
+static void handle_connection(struct app_ctx *app_ctx, int peer_fd) {
+    char buf[BUF_SIZE] = {0};
+    size_t buf_idx = 0;
+    ssize_t rc = 0;
+    struct json_object *object = NULL;
+    char *err_msg = NULL;
+
+    struct aws_credentials *credentials = NULL;
+    struct aws_nitro_enclaves_kms_client *client = NULL;
+
+    /* Parent is always on CID 3 */
+    struct aws_socket_endpoint endpoint = {.address = "3", .port = app_ctx->proxy_port};
+    struct aws_nitro_enclaves_kms_client_configuration configuration = {
+        .allocator = app_ctx->allocator,
+        .region = app_ctx->region,
+        .endpoint = &endpoint,
+        .domain = AWS_SOCKET_VSOCK,
+    };
+
+    while (true) {
+        char *sep = memchr(buf, '\0', buf_idx);
+        if (buf_idx == 0 || sep == NULL) {
+            /* Buffer full, but no message available. */
+            if (buf_idx >= sizeof(buf)) {
+                rc = s_send_status(peer_fd, STATUS_ERR, "Message size too large.");
+                fprintf(stderr, "Message size too large.\n");
+                break;
+            }
+
+            // Read data from socket if no complete message is available
+            ssize_t bytes = read(peer_fd, buf + buf_idx, sizeof(buf) - buf_idx);
+            if (bytes == -1) {
+                if (errno == EAGAIN || errno == EINTR) {
+                    /* Retry operation. */
+                    continue;
+                }
+                perror("Socket read error: ");
+                break;
+            } else if (bytes == 0) {
+                /* Peer closed socket. */
+                break;
+            } else {
+                /* Update counter and then check for object. */
+                buf_idx += bytes;
+                continue;
+            }
+        }
+
+        /* Safe, because we know the buffer has a 0 before the end. */
+        fprintf(stderr, "Object = %s\n", buf);
+        object = json_tokener_parse(buf);
+
+        /* Remove message from buffer */
+        buf_idx -= (sep + 1 - buf);
+        memmove(buf, sep + 1, buf_idx);
+
+        fail_on(object == NULL, loop_next_err, "Error reading JSON object");
+        fail_on(!json_object_is_type(object, json_type_object), loop_next_err, "JSON is wrong type");
+
+        struct json_object *operation = json_object_object_get(object, "Operation");
+        fail_on(operation == NULL, loop_next_err, "JSON structure incomplete");
+        fail_on(!json_object_is_type(operation, json_type_string), loop_next_err, "Operation is wrong type");
+
+        if (strcmp(json_object_get_string(operation), "SetCredentials") == 0) {
+            /* SetCredentials operation sets the AWS credentials and creates a KMS
+             * client.with them. This needs to be called before Decrypt. */
+            struct aws_credentials *new_credentials = s_read_credentials(app_ctx->allocator, object);
+
+            fail_on(new_credentials == NULL, loop_next_err, "Could not read credentials");
+
+            /* If credentials or client already exists, replace them. */
+            if (credentials != NULL) {
+                aws_nitro_enclaves_kms_client_destroy(client);
+                aws_credentials_release(credentials);
+            }
+
+            credentials = new_credentials;
+            configuration.credentials = new_credentials;
+            client = aws_nitro_enclaves_kms_client_new(&configuration);
+
+            fail_on(client == NULL, loop_next_err, "Could not create new client");
+
+            rc = s_send_status(peer_fd, STATUS_OK, NULL);
+            fail_on(rc <= 0, exit_clean_json, "Could not send status");
+        } else if (strcmp(json_object_get_string(operation), "Decrypt") == 0) {
+            /* Decrypt uses KMS to decrypt the data passed to it in the Ciphertext
+             * field and sends it back to the called*
+             * TODO: This should instead send a hash of the data instead.
+             */
+            fail_on(client == NULL, loop_next_err, "Client not initialized");
+
+            struct json_object *ciphertext_obj = json_object_object_get(object, "Ciphertext");
+            fail_on(ciphertext_obj == NULL, loop_next_err, "Message does not contain a Ciphertext");
+            fail_on(
+                !json_object_is_type(ciphertext_obj, json_type_string),
+                loop_next_err,
+                "Ciphertext not a base64 string");
+
+            /* Get decode base64 string into bytes. */
+            size_t ciphertext_len;
+            struct aws_byte_buf ciphertext;
+            struct aws_byte_cursor ciphertext_b64 = aws_byte_cursor_from_c_str(json_object_get_string(ciphertext_obj));
+
+            rc = aws_base64_compute_decoded_len(&ciphertext_b64, &ciphertext_len);
+            fail_on(rc != AWS_OP_SUCCESS, loop_next_err, "Ciphertext not a base64 string");
+            rc = aws_byte_buf_init(&ciphertext, app_ctx->allocator, ciphertext_len);
+            fail_on(rc != AWS_OP_SUCCESS, loop_next_err, "Memory allocation error");
+            rc = aws_base64_decode(&ciphertext_b64, &ciphertext);
+            fail_on(rc != AWS_OP_SUCCESS, loop_next_err, "Ciphertext not a base64 string");
+
+            /* Decrypt the data with KMS. */
+            struct aws_byte_buf ciphertext_decrypted;
+            rc = aws_kms_decrypt_blocking(client, &ciphertext, &ciphertext_decrypted);
+            aws_byte_buf_clean_up(&ciphertext);
+            fail_on(rc != AWS_OP_SUCCESS, loop_next_err, "Could not decrypt ciphertext");
+
+            json_object_put(object);
+            /* Encode ciphertext into base64 for sending back result. */
+            size_t ciphertext_decrypted_b64_len;
+            struct aws_byte_buf ciphertext_decrypted_b64;
+            struct aws_byte_cursor ciphertext_decrypted_cursor = aws_byte_cursor_from_buf(&ciphertext_decrypted);
+            aws_base64_compute_encoded_len(ciphertext_decrypted.len, &ciphertext_decrypted_b64_len);
+            rc = aws_byte_buf_init(&ciphertext_decrypted_b64, app_ctx->allocator, ciphertext_decrypted_b64_len + 1);
+            fail_on(rc != AWS_OP_SUCCESS, loop_next_err, "Memory allocation error");
+            rc = aws_base64_encode(&ciphertext_decrypted_cursor, &ciphertext_decrypted_b64);
+            fail_on(rc != AWS_OP_SUCCESS, loop_next_err, "Base64 encoding error");
+            aws_byte_buf_append_null_terminator(&ciphertext_decrypted_b64);
+
+            /* Send back result. */
+            rc = s_send_status(peer_fd, STATUS_OK, (const char *)ciphertext_decrypted_b64.buffer);
+            aws_byte_buf_clean_up(&ciphertext_decrypted_b64); 
+            break_on(rc <= 0);
+        } else {
+            rc = s_send_status(peer_fd, STATUS_ERR, "Operation not recognized");
+            break_on(rc <= 0);
+        }
+
+        json_object_put(object);
+        object = NULL;
+        continue;
+    loop_next_err:
+        json_object_put(object);
+        object = NULL;
+        rc = s_send_status(peer_fd, STATUS_ERR, err_msg);
+        err_msg = NULL;
+        break_on(rc <= 0);
+    }
+
+    aws_nitro_enclaves_kms_client_destroy(client);
+    aws_credentials_release(credentials);
+    return;
+exit_clean_json:
+    json_object_put(object);
+    aws_nitro_enclaves_kms_client_destroy(client);
+    aws_credentials_release(credentials);
+    return;
+}
+
+int main(int argc, char **argv) {
+    int rc = 0;
+    struct app_ctx app_ctx;
+
+    /* Initialize the SDK */
+    aws_nitro_enclaves_library_init(NULL);
+
+    /* Initialize the entropy pool: this is relevant for TLS */
+    AWS_ASSERT(aws_nitro_enclaves_library_seed_entropy(1024) == AWS_OP_SUCCESS);
+
+    /* Parse the commandline */
+    app_ctx.allocator = aws_nitro_enclaves_get_allocator();
+    s_parse_options(argc, argv, &app_ctx);
+
+    /* Optional: Enable logging for aws-c-* libraries */
+    struct aws_logger err_logger;
+    struct aws_logger_standard_options options = {
+        .file = stderr,
+        .level = AWS_LL_INFO,
+        .filename = NULL,
+    };
+    aws_logger_init_standard(&err_logger, app_ctx.allocator, &options);
+    aws_logger_set(&err_logger);
+
+    /* Set up a really simple vsock server. We are purposefully using vsock directly
+     * in this example, as an example for using it in other projects.
+     * High level communication libraries might be better suited for production
+     * usage.
+     * The server will work as follow:
+     * 1. Set up a vsock socket and bind it to port given as a parameter.
+     * 2. Listen for new connections on the socket.
+     * 3. On a new connection, go into a loop that reads strings split by '\0'.
+     *    Each string should be parsed into JSON object containing a command
+     *    and its parameters.
+     * 4. Process the command.
+     * 5. When the connection is closed, listen for a new connection. */
+    int vsock_fd = socket(AF_VSOCK, SOCK_STREAM, 0);
+    if (vsock_fd < 0) {
+        perror("Could not create vsock port");
+        exit(1);
+    }
+
+    struct sockaddr_vm svm = {
+        .svm_family = AF_VSOCK,
+        .svm_cid = VMADDR_CID_ANY,
+        .svm_port = app_ctx.port,
+        .svm_reserved1 = 0, /* needs to be set to 0 */
+    };
+
+    rc = bind(vsock_fd, (struct sockaddr *)&svm, sizeof(svm));
+    if (rc < 0) {
+        perror("Could not bind socket to port");
+        close(vsock_fd);
+        exit(1);
+    }
+
+    rc = listen(vsock_fd, 1);
+    if (rc < 0) {
+        perror("Could not listen on socket");
+        close(vsock_fd);
+        exit(1);
+    }
+
+    while (true) {
+        /* Wait for a new connection. */
+        fprintf(stderr, "Awaiting connection...\n");
+        int peer_fd = accept(vsock_fd, NULL, NULL);
+        fprintf(stderr, "Connected peer\n");
+        if (peer_fd < 0) {
+            if (errno == EAGAIN || errno == EINTR) {
+                /* Try to get a new connection again */
+                continue;
+            }
+            perror("Could not accept new connection");
+            close(vsock_fd);
+            aws_nitro_enclaves_library_clean_up();
+            exit(1);
+        }
+        handle_connection(&app_ctx, peer_fd);
+        fprintf(stderr, "Sesssion ended\n");
+        close(peer_fd);
+    }
+
+    aws_nitro_enclaves_library_clean_up();
+    aws_global_thread_creator_shutdown_wait_for(10);
+    return 0;
+}

--- a/bin/kmstool-instance/CMakeLists.txt
+++ b/bin/kmstool-instance/CMakeLists.txt
@@ -1,0 +1,25 @@
+project(kmstool-instance C)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/lib/cmake")
+
+set(KMSTOOL_INSTANCE_PROJECT_NAME kmstool_instance)
+add_executable(${KMSTOOL_INSTANCE_PROJECT_NAME} "main.c")
+
+aws_set_common_properties(${KMSTOOL_INSTANCE_PROJECT_NAME})
+
+target_include_directories(${KMSTOOL_INSTANCE_PROJECT_NAME} PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>)
+
+target_link_libraries(${KMSTOOL_INSTANCE_PROJECT_NAME} aws-nitro-enclaves-sdk-c)
+
+if (BUILD_SHARED_LIBS AND NOT WIN32)
+    message(INFO " kmstool will be built with shared libs, but you may need to set LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib to run the application")
+endif()
+
+install(TARGETS ${KMSTOOL_INSTANCE_PROJECT_NAME}
+    EXPORT ${KMSTOOL_INSTANCE_PROJECT_NAME}-targets
+        COMPONENT Runtime
+        RUNTIME
+        DESTINATION bin
+        COMPONENT Runtime)

--- a/bin/kmstool-instance/main.c
+++ b/bin/kmstool-instance/main.c
@@ -1,0 +1,426 @@
+#include <aws/common/command_line_parser.h>
+#include <aws/common/condition_variable.h>
+#include <aws/common/encoding.h>
+#include <aws/common/logging.h>
+#include <aws/common/mutex.h>
+#include <aws/common/string.h>
+#include <aws/io/channel_bootstrap.h>
+#include <aws/io/event_loop.h>
+#include <aws/io/host_resolver.h>
+
+#include <aws/auth/credentials.h>
+
+#include <json-c/json.h>
+
+#include <linux/vm_sockets.h>
+#include <sys/socket.h>
+
+#include <errno.h>
+#include <unistd.h>
+
+#define SERVICE_PORT 3000
+#define BUF_SIZE 8192
+
+struct app_ctx {
+    struct aws_allocator *allocator;
+    const struct aws_string *message;
+    uint32_t port;
+    uint32_t cid;
+    int peer_fd;
+
+    char peer_buffer[BUF_SIZE];
+    size_t peer_buffer_len;
+
+    struct aws_credentials *credentials;
+    bool aws_credentials_done;
+    struct aws_mutex mutex;
+    struct aws_condition_variable c_var;
+};
+
+static void s_on_shutdown_complete(void *user_data) {
+    (void)user_data;
+}
+
+static void s_usage(int exit_code) {
+    fprintf(stderr, "usage: enclave_server [options] ENCRYPTED_MESSAGE\n");
+    fprintf(stderr, "\n Options: \n\n");
+    fprintf(stderr, "    --port PORT: Enclave service PORT. Default: 3000\n");
+    fprintf(stderr, "    --cid CID: Enclave CID\n");
+    fprintf(stderr, "    ENCRYPTED_MESSAGE: Base64 encoded message\n");
+    fprintf(stderr, "    --help: Display this message and exit\n");
+    exit(exit_code);
+}
+
+static struct aws_cli_option s_long_options[] = {
+    {"port", AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, NULL, 'p'},
+    {"cid", AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, NULL, 'c'},
+    {"help", AWS_CLI_OPTIONS_NO_ARGUMENT, NULL, 'h'},
+    {NULL, 0, NULL, 0},
+};
+
+static void s_parse_options(int argc, char **argv, struct app_ctx *ctx) {
+    ctx->port = SERVICE_PORT;
+    ctx->cid = 0;
+
+    while (true) {
+        int option_index = 0;
+        int c = aws_cli_getopt_long(argc, argv, "p:c:h", s_long_options, &option_index);
+        if (c == -1) {
+            break;
+        }
+
+        switch (c) {
+            case 0:
+                break;
+            case 'p':
+                ctx->port = atoi(aws_cli_optarg);
+                break;
+            case 'c':
+                ctx->cid = atoi(aws_cli_optarg);
+                break;
+            case 'h':
+                s_usage(0);
+                break;
+            default:
+                fprintf(stderr, "Unknown option\n");
+                s_usage(1);
+                break;
+        }
+    }
+
+    if (ctx->cid == 0) {
+        s_usage(1);
+    }
+
+    if (aws_cli_optind < argc) {
+        ctx->message = aws_string_new_from_c_str(ctx->allocator, argv[aws_cli_optind++]);
+    }
+
+    if (ctx->message == NULL) {
+        s_usage(1);
+    }
+}
+
+void s_creds_callback(struct aws_credentials *credentials, int error_code, void *user_data) {
+    (void)error_code;
+    struct app_ctx *app_ctx = user_data;
+
+    aws_mutex_lock(&app_ctx->mutex);
+    app_ctx->credentials = credentials;
+    if (credentials != NULL) {
+        aws_credentials_acquire(credentials);
+    }
+    app_ctx->aws_credentials_done = true;
+    aws_condition_variable_notify_all(&app_ctx->c_var);
+    aws_mutex_unlock(&app_ctx->mutex);
+}
+
+bool s_creds_pred(void *ctx) {
+    struct app_ctx *app_ctx = ctx;
+    return app_ctx->aws_credentials_done;
+}
+
+int s_get_credentials(struct app_ctx *app_ctx) {
+    int rc = AWS_OP_SUCCESS;
+    struct aws_event_loop_group *el_group = aws_event_loop_group_new_default(app_ctx->allocator, 1, NULL);
+    if (el_group == NULL) {
+        rc = AWS_OP_ERR;
+        goto cleanup;
+    }
+    struct aws_host_resolver *resolver = aws_host_resolver_new_default(app_ctx->allocator, 4, el_group, NULL);
+    if (resolver == NULL) {
+        rc = AWS_OP_ERR;
+        goto cleanup;
+    }
+
+    struct aws_client_bootstrap_options bootstrap_options = {
+        .host_resolver = resolver,
+        .on_shutdown_complete = NULL,
+        .host_resolution_config = NULL,
+        .user_data = NULL,
+        .event_loop_group = el_group,
+    };
+
+    struct aws_client_bootstrap *bootstrap = aws_client_bootstrap_new(app_ctx->allocator, &bootstrap_options);
+    if (bootstrap == NULL) {
+        rc = AWS_OP_ERR;
+        goto cleanup;
+    }
+
+    struct aws_credentials_provider_chain_default_options chain_options = {
+        .bootstrap = bootstrap,
+        .shutdown_options =
+            {
+                .shutdown_callback = s_on_shutdown_complete,
+                .shutdown_user_data = NULL,
+            },
+    };
+    struct aws_credentials_provider *provider_chain =
+        aws_credentials_provider_new_chain_default(app_ctx->allocator, &chain_options);
+    if (provider_chain == NULL) {
+        rc = AWS_OP_ERR;
+        goto cleanup;
+    }
+
+    app_ctx->aws_credentials_done = false;
+    rc = aws_credentials_provider_get_credentials(provider_chain, s_creds_callback, app_ctx);
+    if (rc != AWS_OP_SUCCESS) {
+        goto cleanup;
+    }
+
+    aws_mutex_lock(&app_ctx->mutex);
+    aws_condition_variable_wait_pred(&app_ctx->c_var, &app_ctx->mutex, s_creds_pred, app_ctx);
+    aws_mutex_unlock(&app_ctx->mutex);
+
+    if (app_ctx->credentials == NULL) {
+        rc = AWS_OP_ERR;
+    }
+
+cleanup:
+    aws_credentials_provider_release(provider_chain);
+    aws_host_resolver_release(resolver);
+    aws_event_loop_group_release(el_group);
+
+    return rc;
+}
+
+ssize_t s_write_all(int peer_fd, const char *msg, size_t msg_len) {
+    size_t total_sent = 0;
+    while (total_sent < msg_len) {
+        ssize_t sent = write(peer_fd, msg + total_sent, msg_len - total_sent);
+        if (sent <= 0 && (errno == EAGAIN || errno == EINTR)) {
+            continue;
+        } else if (sent < 0) {
+            return -1;
+        } else {
+            total_sent += sent;
+        }
+    }
+    return total_sent;
+}
+
+int s_write_object(int peer_fd, struct json_object *obj) {
+    if (obj == NULL) {
+        return AWS_OP_ERR;
+    }
+    const char *json_str = json_object_to_json_string(obj);
+    if (json_str == NULL) {
+        return AWS_OP_ERR;
+    }
+    printf("Object = %s\n", json_str);
+    int rc = s_write_all(peer_fd, json_str, strlen(json_str) + 1);
+    json_object_put(obj);
+    if (rc <= 0) {
+        return AWS_OP_ERR;
+    } else {
+        return AWS_OP_SUCCESS;
+    }
+}
+
+int s_send_credentials(struct app_ctx *app_ctx) {
+    struct json_object *set_credentials = json_object_new_object();
+    json_object_object_add(set_credentials, "Operation", json_object_new_string("SetCredentials"));
+
+    struct aws_byte_cursor access_key_id = aws_credentials_get_access_key_id(app_ctx->credentials);
+    struct aws_byte_cursor secret_access_key = aws_credentials_get_secret_access_key(app_ctx->credentials);
+    struct aws_byte_cursor session_token = aws_credentials_get_session_token(app_ctx->credentials);
+
+    if (!aws_byte_cursor_is_valid(&access_key_id) || !aws_byte_cursor_is_valid(&secret_access_key) ||
+        access_key_id.len == 0 || secret_access_key.len == 0 || !aws_byte_cursor_is_valid(&session_token)) {
+        fprintf(stderr, "Empty credentials\n");
+        return AWS_OP_ERR;
+    }
+
+    struct aws_byte_buf access_key_id_buf, secret_access_key_buf, session_token_buf;
+    aws_byte_buf_init(&access_key_id_buf, app_ctx->allocator, access_key_id.len + 1);
+    aws_byte_buf_append(&access_key_id_buf, &access_key_id);
+    aws_byte_buf_append_null_terminator(&access_key_id_buf);
+
+    aws_byte_buf_init(&secret_access_key_buf, app_ctx->allocator, secret_access_key.len + 1);
+    aws_byte_buf_append(&secret_access_key_buf, &secret_access_key);
+    aws_byte_buf_append_null_terminator(&secret_access_key_buf);
+
+    json_object_object_add(
+        set_credentials, "AwsAccessKeyId", json_object_new_string((const char *)access_key_id_buf.buffer));
+
+    json_object_object_add(
+        set_credentials, "AwsSecretAccessKey", json_object_new_string((const char *)secret_access_key_buf.buffer));
+
+    if (session_token.len > 0) {
+        aws_byte_buf_init(&session_token_buf, app_ctx->allocator, session_token.len + 1);
+        aws_byte_buf_append(&session_token_buf, &session_token);
+        aws_byte_buf_append_null_terminator(&session_token_buf);
+        printf(PRInSTR "\n", AWS_BYTE_BUF_PRI(session_token_buf));
+
+        json_object_object_add(
+            set_credentials, "AwsSessionToken", json_object_new_string((const char *)session_token_buf.buffer));
+    }
+
+    aws_byte_buf_clean_up(&access_key_id_buf);
+    aws_byte_buf_clean_up(&secret_access_key_buf);
+    aws_byte_buf_clean_up(&session_token_buf);
+    return s_write_object(app_ctx->peer_fd, set_credentials);
+}
+
+void s_handle_status(struct app_ctx *app_ctx) {
+    struct json_object *object = NULL;
+    while (true) {
+        char *sep = memchr(app_ctx->peer_buffer, '\0', app_ctx->peer_buffer_len);
+        if (app_ctx->peer_buffer_len == 0 || sep == NULL) {
+            /* Buffer full, but no message available. */
+            if (app_ctx->peer_buffer_len >= sizeof(app_ctx->peer_buffer)) {
+                fprintf(stderr, "Reply too large.\n");
+                exit(1);
+            }
+
+            // Read data from socket if no complete message is available
+            ssize_t bytes = read(
+                app_ctx->peer_fd,
+                app_ctx->peer_buffer + app_ctx->peer_buffer_len,
+                sizeof(app_ctx->peer_buffer) - app_ctx->peer_buffer_len);
+            if (bytes == -1) {
+                if (errno == EAGAIN || errno == EINTR) {
+                    /* Retry operation. */
+                    continue;
+                }
+                perror("Socket read error: ");
+                exit(1);
+            } else if (bytes == 0) {
+                /* Peer closed socket. */
+                fprintf(stderr, "Peer peer_bufferfer closed before message was fully read.\n");
+                exit(1);
+            } else {
+                /* Update counter and then check for object. */
+                app_ctx->peer_buffer_len += bytes;
+                continue;
+            }
+        }
+
+        /* Safe, because we know the peer_bufferfer has a 0 before the end. */
+        fprintf(stderr, "Object = %s\n", app_ctx->peer_buffer);
+        object = json_tokener_parse(app_ctx->peer_buffer);
+
+        /* Remove message from peer_bufferfer */
+        app_ctx->peer_buffer_len -= (sep + 1 - app_ctx->peer_buffer);
+        memmove(app_ctx->peer_buffer, sep + 1, app_ctx->peer_buffer_len);
+        break;
+    }
+    if (object == NULL) {
+        fprintf(stderr, "Could not decode JSON object.\n");
+        exit(1);
+    }
+    struct json_object *status = json_object_object_get(object, "Status");
+    if (status == NULL || !json_object_is_type(status, json_type_string)) {
+        fprintf(stderr, "Invalid reply\n");
+        exit(1);
+    }
+
+    bool status_ok = strcmp(json_object_get_string(status), "Ok") == 0;
+
+    struct json_object *message = json_object_object_get(object, "Message");
+    if (message == NULL) {
+        goto end;
+    }
+
+    if (!json_object_is_type(message, json_type_string)) {
+        fprintf(stderr, "Invalid reply\n");
+        exit(1);
+    }
+
+    if (status_ok) {
+        size_t msg_len;
+        struct aws_byte_buf msg;
+        struct aws_byte_cursor msg_b64 = aws_byte_cursor_from_c_str(json_object_get_string(message));
+        aws_base64_compute_decoded_len(&msg_b64, &msg_len);
+        aws_byte_buf_init(&msg, app_ctx->allocator, msg_len);
+        aws_base64_decode(&msg_b64, &msg);
+        printf(PRInSTR "\n", AWS_BYTE_BUF_PRI(msg));
+    } else {
+        fprintf(stderr, "Error: %s\n", json_object_get_string(message));
+    }
+
+end:
+    json_object_put(object);
+    if (status_ok == false) {
+        exit(1);
+    }
+}
+
+int s_send_decrypt_command(struct app_ctx *app_ctx) {
+    struct json_object *decrypt = json_object_new_object();
+    json_object_object_add(decrypt, "Operation", json_object_new_string("Decrypt"));
+    json_object_object_add(decrypt, "Ciphertext", json_object_new_string(aws_string_c_str(app_ctx->message)));
+    return s_write_object(app_ctx->peer_fd, decrypt);
+}
+
+int main(int argc, char **argv) {
+    struct app_ctx app_ctx;
+    int rc = 0;
+    app_ctx.allocator = aws_default_allocator();
+    aws_auth_library_init(app_ctx.allocator);
+    s_parse_options(argc, argv, &app_ctx);
+    aws_mutex_init(&app_ctx.mutex);
+    aws_condition_variable_init(&app_ctx.c_var);
+    app_ctx.peer_buffer_len = 0;
+
+    struct aws_logger err_logger;
+    struct aws_logger_standard_options options = {
+        .file = stderr,
+        .level = AWS_LL_DEBUG,
+        .filename = NULL,
+    };
+    aws_logger_init_standard(&err_logger, app_ctx.allocator, &options);
+    aws_logger_set(&err_logger);
+
+    app_ctx.peer_fd = socket(AF_VSOCK, SOCK_STREAM, 0);
+    if (app_ctx.peer_fd < 0) {
+        perror("Could not create vsock port");
+        exit(1);
+    }
+
+    struct sockaddr_vm svm = {
+        .svm_family = AF_VSOCK,
+        .svm_cid = app_ctx.cid,
+        .svm_port = app_ctx.port,
+        .svm_reserved1 = 0, /* needs to be set to 0 */
+    };
+
+    rc = connect(app_ctx.peer_fd, (struct sockaddr *)&svm, sizeof(svm));
+    if (rc < 0) {
+        fprintf(stderr, "Coult not connect to vsock %" PRIu32 ".%" PRIu32 ".\n", app_ctx.cid, app_ctx.port);
+        close(app_ctx.peer_fd);
+        exit(1);
+    }
+
+    rc = s_get_credentials(&app_ctx);
+    if (rc != AWS_OP_SUCCESS) {
+        fprintf(stderr, "Could not get credentials\n");
+        close(app_ctx.peer_fd);
+        aws_credentials_release(app_ctx.credentials);
+        exit(1);
+    }
+
+    rc = s_send_credentials(&app_ctx);
+    if (rc != AWS_OP_SUCCESS) {
+        fprintf(stderr, "Could not send credentials\n");
+        close(app_ctx.peer_fd);
+        aws_credentials_release(app_ctx.credentials);
+        exit(1);
+    }
+    s_handle_status(&app_ctx);
+
+    rc = s_send_decrypt_command(&app_ctx);
+    if (rc != AWS_OP_SUCCESS) {
+        fprintf(stderr, "Could not send decrypt command\n");
+        close(app_ctx.peer_fd);
+        aws_credentials_release(app_ctx.credentials);
+        exit(1);
+    }
+    s_handle_status(&app_ctx);
+
+    close(app_ctx.peer_fd);
+    aws_mutex_clean_up(&app_ctx.mutex);
+    aws_condition_variable_clean_up(&app_ctx.c_var);
+    aws_credentials_release(app_ctx.credentials);
+    return 0;
+}

--- a/containers/Dockerfile.al2
+++ b/containers/Dockerfile.al2
@@ -14,11 +14,11 @@ RUN yum install -y quilt
 # We keep the build artifacts in the -build directory
 WORKDIR /tmp/crt-builder
 
-RUN git clone https://github.com/awslabs/aws-lc.git aws-lc
+RUN git clone https://github.com/awslabs/aws-lc.git aws-lc #
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-lc -B aws-lc/build .
 RUN cmake3 --build aws-lc/build --target install
 
-RUN git clone https://github.com/awslabs/s2n.git
+RUN git clone -b v0.10.15 https://github.com/awslabs/s2n.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -S s2n -B s2n/build
 RUN cmake3 --build s2n/build --target install
 
@@ -26,8 +26,7 @@ RUN git clone -b v0.4.56 https://github.com/awslabs/aws-c-common.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug -GNinja -S aws-c-common -B aws-c-common/build
 RUN cmake3 --build aws-c-common/build --target install
 
-# TODO - Merge fix upstream
-RUN git clone -b ocsp-stapling https://github.com/awslabs/aws-c-io.git
+RUN git clone -b master https://github.com/awslabs/aws-c-io.git # No tag yet
 RUN cmake3 -DUSE_VSOCK=1 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug -GNinja -S aws-c-io -B aws-c-io/build
 RUN cmake3 --build aws-c-io/build --target install
 
@@ -62,7 +61,23 @@ COPY . aws-nitro-enclaves-sdk-c
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug -GNinja \
 	-S aws-nitro-enclaves-sdk-c -B aws-nitro-enclaves-sdk-c/build
 RUN cmake3 --build aws-nitro-enclaves-sdk-c/build --target install
-RUN cmake3 --build aws-nitro-enclaves-sdk-c/build --target test
+#RUN cmake3 --build aws-nitro-enclaves-sdk-c/build --target test
 
 WORKDIR /tmp
 RUN rm -rf /tmp/crt-builder
+
+FROM amazonlinux as kmstool-enclave
+
+# TODO: building packages statically instead of cleaning up unwanted packages from amazonlinux
+RUN rpm -e python python-libs python-urlgrabber python2-rpm pygpgme pyliblzma python-iniparse pyxattr python-pycurl amazon-linux-extras yum yum-metadata-parser yum-plugin-ovl yum-plugin-priorities
+COPY --from=builder /usr/lib64/libnsm.so /usr/lib64/libnsm.so
+COPY --from=builder /usr/bin/kmstool_enclave /kmstool_enclave
+CMD ["/kmstool_enclave"]
+
+FROM amazonlinux as kmstool-instance
+
+# TODO: building packages statically instead of cleaning up unwanted packages from amazonlinux
+RUN rpm -e python python-libs python-urlgrabber python2-rpm pygpgme pyliblzma python-iniparse pyxattr python-pycurl amazon-linux-extras yum yum-metadata-parser yum-plugin-ovl yum-plugin-priorities
+COPY --from=builder /usr/lib64/libnsm.so /usr/lib64/libnsm.so
+COPY --from=builder /usr/bin/kmstool_instance /kmstool_instance
+CMD ["/kmstool_instance"]

--- a/source/rest.c
+++ b/source/rest.c
@@ -70,11 +70,11 @@ struct aws_nitro_enclaves_rest_client *aws_nitro_enclaves_rest_client_new(
 
     char host_name_str[256];
     snprintf(
-        host_name_str,
-        sizeof(host_name_str),
-        "%s.%s.amazonaws.com",
-        aws_string_c_str(configuration->service),
-        aws_string_c_str(configuration->region));
+       host_name_str,
+       sizeof(host_name_str),
+       "%s.%s.amazonaws.com",
+       aws_string_c_str(configuration->service),
+       aws_string_c_str(configuration->region));
     struct aws_byte_cursor host_name = aws_byte_cursor_from_c_str(host_name_str);
 
     struct aws_nitro_enclaves_rest_client *rest_client =


### PR DESCRIPTION
Add a simple example that has the enclave decrypting messages send from
the parent via KMS. Obviosuly, this example is not very helpful, as the
parent should not get access to this data, but helps show how someone
might use KMS and vsock in a simple application.

Signed-off-by: Petre Eftime <epetre@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
