### PR TITLE
container: update library version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,29 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 This project is licensed under the Apache-2.0 License.
 
 ## Dependencies
-OpenSSL 1.1 https://www.openssl.org  
-S2N https://github.com/awslabs/s2n  
-aws-c-common https://github.com/awslabs/aws-c-common  
-aws-c-io https://github.com/awslabs/aws-c-io  
-aws-c-compression http://github.com/awslabs/aws-c-compression  
-aws-c-http https://github.com/awslabs/aws-c-http
+| name                       | version              | link                                              |
+|----------------------------|----------------------|---------------------------------------------------|
+| aws-lc                     | v0.1-beta            | https://github.com/awslabs/aws-lc/                |
+| S2N                        | v0.10.21             | https://github.com/awslabs/s2n                    |
+| aws-c-common               | v0.4.59              | https://github.com/awslabs/aws-c-common           |
+| aws-c-io                   | v0.7.0               | https://github.com/awslabs/aws-c-io               |
+| aws-c-compression          | v0.2.10              | https://github.com/awslabs/aws-c-compression       |
+| aws-c-http                 | v0.5.17              | https://github.com/awslabs/aws-c-http             |
+| aws-c-cal                  | v0.3.3               | https://github.com/awslabs/aws-c-cal              |
+| aws-c-auth                 | v0.4.6               | https://github.com/awslabs/aws-c-auth             |
+| aws-nitro-enclaves-nsm-api | v0.1.0               | https://github.com/aws/aws-nitro-enclaves-nsm-api |
+| json-c                     | json-c-0.15-20200726 | https://github.com/json-c/json-c                  |
 
-## Build Containers
-* Amazon Linux 2: containers/Dockerfile.al2
+## Building
+
+### Using containers:
+The simplest way to use this SDK is by using one of the available containers as a base:
+```
+docker build -f --target builder -t aws-nitro-enclaves-sdk-c containers/Dockerfile.al2 .
+```
+
+
+## Samples
+ * [kmstool](docs/kmstool.md)
+ * [kmstool-enclave-cli](docs/kmstool.md#kmstool-enclave-cli)
+

--- a/containers/Dockerfile.al2
+++ b/containers/Dockerfile.al2
@@ -14,19 +14,23 @@ RUN yum install -y quilt
 # We keep the build artifacts in the -build directory
 WORKDIR /tmp/crt-builder
 
-RUN git clone https://github.com/awslabs/aws-lc.git aws-lc #
+RUN git clone -b v0.1-beta https://github.com/awslabs/aws-lc.git aws-lc #
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-lc -B aws-lc/build .
 RUN cmake3 --build aws-lc/build --target install
 
-RUN git clone -b v0.10.15 https://github.com/awslabs/s2n.git
+RUN git clone -b v0.10.21 https://github.com/awslabs/s2n.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -S s2n -B s2n/build
 RUN cmake3 --build s2n/build --target install
 
-RUN git clone -b v0.4.56 https://github.com/awslabs/aws-c-common.git
+RUN git clone -b v0.4.59 https://github.com/awslabs/aws-c-common.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug -GNinja -S aws-c-common -B aws-c-common/build
 RUN cmake3 --build aws-c-common/build --target install
 
-RUN git clone -b main https://github.com/awslabs/aws-c-io.git # No tag yet
+RUN git clone -b v0.3.3 https://github.com/awslabs/aws-c-cal.git
+RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-cal -B aws-c-cal/build
+RUN cmake3 --build aws-c-cal/build --target install
+
+RUN git clone -b v0.7.0 https://github.com/awslabs/aws-c-io.git
 RUN cmake3 -DUSE_VSOCK=1 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug -GNinja -S aws-c-io -B aws-c-io/build
 RUN cmake3 --build aws-c-io/build --target install
 
@@ -38,22 +42,19 @@ RUN git clone -b v0.5.17 https://github.com/awslabs/aws-c-http.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug -GNinja -S aws-c-http -B aws-c-http/build
 RUN cmake3 --build aws-c-http/build --target install
 
-RUN git clone -b v0.3.0 https://github.com/awslabs/aws-c-cal.git
-RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-cal -B aws-c-cal/build
-RUN cmake3 --build aws-c-cal/build --target install
-
-RUN git clone -b v0.4.1 https://github.com/awslabs/aws-c-auth.git
+RUN git clone -b v0.4.6 https://github.com/awslabs/aws-c-auth.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-auth -B aws-c-auth/build
 RUN cmake3 --build aws-c-auth/build --target install
 
-RUN git clone -b json-c-0.14-20200419 https://github.com/json-c/json-c.git
+RUN git clone -b json-c-0.15-20200726 https://github.com/json-c/json-c.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=OFF -GNinja -S json-c -B json-c/build
 RUN cmake3 --build json-c/build --target install
 
-RUN git clone https://github.com/aws/aws-nitro-enclaves-nsm-api.git
+RUN git clone -b v0.1.0 https://github.com/aws/aws-nitro-enclaves-nsm-api.git
 RUN source $HOME/.cargo/env && cd aws-nitro-enclaves-nsm-api && cargo build --release
 RUN mv aws-nitro-enclaves-nsm-api/target/release/libnsm.so /usr/lib64
 RUN mv aws-nitro-enclaves-nsm-api/target/release/nsm.h /usr/include
+
 
 COPY . aws-nitro-enclaves-sdk-c
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug -GNinja \

--- a/containers/Dockerfile.al2
+++ b/containers/Dockerfile.al2
@@ -23,7 +23,7 @@ RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -S s2n -B s2n/bu
 RUN cmake3 --build s2n/build --target install
 
 RUN git clone -b v0.4.59 https://github.com/awslabs/aws-c-common.git
-RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug -GNinja -S aws-c-common -B aws-c-common/build
+RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-common -B aws-c-common/build
 RUN cmake3 --build aws-c-common/build --target install
 
 RUN git clone -b v0.3.3 https://github.com/awslabs/aws-c-cal.git
@@ -31,7 +31,7 @@ RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c
 RUN cmake3 --build aws-c-cal/build --target install
 
 RUN git clone -b v0.7.0 https://github.com/awslabs/aws-c-io.git
-RUN cmake3 -DUSE_VSOCK=1 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug -GNinja -S aws-c-io -B aws-c-io/build
+RUN cmake3 -DUSE_VSOCK=1 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-io -B aws-c-io/build
 RUN cmake3 --build aws-c-io/build --target install
 
 RUN git clone -b v0.2.10 http://github.com/awslabs/aws-c-compression.git
@@ -39,7 +39,7 @@ RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c
 RUN cmake3 --build aws-c-compression/build --target install
 
 RUN git clone -b v0.5.17 https://github.com/awslabs/aws-c-http.git
-RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug -GNinja -S aws-c-http -B aws-c-http/build
+RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-http -B aws-c-http/build
 RUN cmake3 --build aws-c-http/build --target install
 
 RUN git clone -b v0.4.6 https://github.com/awslabs/aws-c-auth.git
@@ -57,7 +57,7 @@ RUN mv aws-nitro-enclaves-nsm-api/target/release/nsm.h /usr/include
 
 
 COPY . aws-nitro-enclaves-sdk-c
-RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug -GNinja \
+RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja \
 	-S aws-nitro-enclaves-sdk-c -B aws-nitro-enclaves-sdk-c/build
 RUN cmake3 --build aws-nitro-enclaves-sdk-c/build --target install
 

--- a/docs/kmstool.md
+++ b/docs/kmstool.md
@@ -10,8 +10,6 @@ calls the KMS using attestation, decrypting a message received from the
 instance side. Since this is a sample, it only allows one connection at
 a time, in order to simplify the workflow.
 
-   There is a rewrite version of **kmstool-enclave** that run as a standalone application, which can directly interact with different application running in enclave. See more detail in `bin/kmstool-enclave-cli`
-
 2. **kmstool-instance** runs on the instance and connects to
 **kmstool-enclave**, passing credentials to the enclave and then
 requesting that the enclave decrypt a base64-encoded message.
@@ -298,3 +296,7 @@ KMS_KEY_ARN=$(aws kms create-key --description "Nitro Enclaves Production Key" -
 
 From this point forward, all steps are the same, except that you will not be able
 to connect to the console of the enclave.
+
+## kmstool-enclave-cli
+There is a rewrite version of **kmstool-enclave** that run as a standalone application, which can directly interact with different application running in an enclave.
+See more detail in `bin/kmstool-enclave-cli`


### PR DESCRIPTION
Some of the dependencies were not fixed at a particular commit, so they
ended up causing issues on (non-cached) builds. This commit updates and
fixes the versions used in the build container, and lists them
explicitly in the README.

There are also some minor README updates.

Signed-off-by: Petre Eftime <epetre@amazon.com>

*Issue #, if available:*
https://github.com/aws/aws-nitro-enclaves-sdk-c/issues/26

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
