### PR TITLE
kmstool-enclave: avoid double-free

### DIFF
--- a/bin/kmstool-enclave/main.c
+++ b/bin/kmstool-enclave/main.c
@@ -322,6 +322,7 @@ static void handle_connection(struct app_ctx *app_ctx, int peer_fd) {
             fail_on(rc != AWS_OP_SUCCESS, loop_next_err, "Could not decrypt ciphertext");
 
             json_object_put(object);
+            object = NULL;
             /* Encode ciphertext into base64 for sending back result. */
             size_t ciphertext_decrypted_b64_len;
             struct aws_byte_buf ciphertext_decrypted_b64;


### PR DESCRIPTION
*Description of changes:*

This object was also released again afterwards, leading to an assertion failure:
```
kmstool_enclave: ../json_object.c:308: json_object_put: Assertion `jso->_ref_count > 0' failed.
```
Signed-off-by: Petre Eftime <epetre@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
