### PR TITLE
Fix kmstool install instructions

### DIFF
--- a/docs/kmstool.md
+++ b/docs/kmstool.md
@@ -58,9 +58,10 @@ an init process. For this step you need to install
 On Amazon Linux 2, you can run:
 ```sh
 sudo amazon-linux-extras install docker
-sudo service docker start
-sudo service docker enable
+sudo systemctl start docker
+sudo systemctl enable docker
 sudo usermod -a -G docker ec2-user
+sudo amazon-linux-extras enable aws-nitro-enclaves-cli
 sudo yum install -y aws-nitro-enclaves-cli aws-nitro-enclaves-cli-devel
 ```
 


### PR DESCRIPTION
The instructions were not working properly on the latest AL2. Update the
instructions so they can be copy-pasted in an instance.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
