### PR TITLE
Create build output folder on user's behalf

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -125,8 +125,9 @@ if (Test-Path -Type Container $SrcPath){
 if (Test-Path -Type Container $BuildOutputPath){
     $ScratchFolder = $(Resolve-Path -Path $BuildOutputPath).Path;
 } else {
-    Write-Output("Unable to access build output path")
-    Exit
+    Write-Output("Unable to access build output path - creating new folder")
+    New-Item -Type Container $BuildOutputPath
+    $ScratchFolder = $(Resolve-Path -Path $BuildOutputPath).Path;
 }
 
 $ModuleList = New-Object System.Collections.ArrayList


### PR DESCRIPTION
Currently, the windows build script expects the parameter BuildOutputPath to be a valid path.  This change enables this parameter to be optional and allows user to specify a path and let the script create a folder at that path if it does not exist.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
