### PR TITLE
Update docs to reference multiple terminals and other improvements

### DIFF
--- a/docs/kmstool.md
+++ b/docs/kmstool.md
@@ -48,7 +48,7 @@ purpose, as the repositories already provide the required packages.
 Follow the documentation on how to start an instance
 [here](https://docs.aws.amazon.com/enclaves/latest/user/create-enclave.html#launch-parent). The next steps will be run inside that instance.
 
-> Note: The guide will also assume you have an IAM role attached to an instance profile and associated to the instance. For more information on instance profiles [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html).
+> Note: The guide will also assume you have an IAM role attached to an instance profile and associated to the instance. You can find more information on instance profiles [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html).
 
 Nitro Enclaves can be built from a docker container, alongside a kernel and
 an init process. For this step you need to install
@@ -91,7 +91,7 @@ copy it over to an enclave-enabled EC2 instance running Windows.
 Follow the documentation on how to start a Windows EC2 instance
 [here](https://docs.aws.amazon.com/enclaves/latest/user/create-enclave.html#launch-parent). The next steps will be run inside that instance.
 
-> Note: The guide will also assume you have an IAM role attached to an instance profile and associated to the instance. For more information on instance profiles [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html).
+> Note: The guide will also assume you have an IAM role attached to an instance profile and associated to the instance. You can find more information on instance profiles [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html).
 
 To build the kmstool-instance sample on Windows, you will need to install 
 visual studio build tools, cmake and git.  These can be installed using [Chocolatey](https://chocolatey.org/install).

--- a/docs/kmstool.md
+++ b/docs/kmstool.md
@@ -260,14 +260,14 @@ Windows instructions are preceded with `PowerShell`
 
 In a second (new) terminal session, start the enclave in debug mode and connect:
 ```sh
-nitro-cli run-enclave --eif-path kmstool.eif --memory 512 --cpu-count 2 --debug-mode
+nitro-cli run-enclave --eif-path kmstool.eif --memory 1024 --cpu-count 2 --debug-mode
 ENCLAVE_ID=$(nitro-cli describe-enclaves | jq -r .[0].EnclaveID)
 # Connect to the enclave's terminal
 nitro-cli console --enclave-id $ENCLAVE_ID
 ```
 PowerShell:
 ```powershell
-nitro-cli run-enclave --eif-path kmstool.eif --memory 512 --cpu-count 2 --debug-mode
+nitro-cli run-enclave --eif-path kmstool.eif --memory 1024 --cpu-count 2 --debug-mode
 $EnclaveID=$(nitro-cli describe-enclaves | ConvertFrom-Json).EnclaveID
 ```
 
@@ -369,8 +369,7 @@ be identical.
 KMS_KEY_ARN=$(aws kms create-key --description "Nitro Enclaves Production Key" --policy file://test-enclave-policy.json --query KeyMetadata.Arn --output text)
 ```
 
-From this point forward, all steps are the same, except that you will not be able
-to connect to the console of the enclave.
+From this point forward, all steps are the same, except that you omit the `--debug-mode` option on the `nitro-cli run-enclave` command and you will not be able to connect to the console of the enclave. Decrypt actions between the Nitro enclave and AWS KMS will make use of and enforce the PCR values specified in the key policy.
 
 ## kmstool-enclave-cli
 There is a rewrite version of **kmstool-enclave** that run as a standalone application, which can directly interact with different application running in an enclave.


### PR DESCRIPTION
*Description of changes:*
Updates to kmstool doc steps to include:
* references to different terminal sessions
* note on instance profile associated with instance
* note on log out and back in for related Nitro Enclaves CLI user permissions to take effect
* updates to memory allocation to account for EIF requirements

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
