### PR TITLE
clang: Apply clang-format

### DIFF
--- a/bin/kmstool-enclave-cli/main.c
+++ b/bin/kmstool-enclave-cli/main.c
@@ -116,31 +116,31 @@ static void s_parse_options(int argc, char **argv, struct app_ctx *ctx) {
     }
 
     // Check if AWS access key ID is set
-    if(ctx->aws_access_key_id == NULL){
+    if (ctx->aws_access_key_id == NULL) {
         fprintf(stderr, "--aws-access-key-id must be set\n");
         exit(1);
     }
 
     // Check if AWS secret access key is set
-    if(ctx->aws_secret_access_key == NULL){
+    if (ctx->aws_secret_access_key == NULL) {
         fprintf(stderr, "--aws-secret-access-key must be set\n");
         exit(1);
     }
 
     // Check if AWS session token is set
-    if(ctx->aws_session_token == NULL){
+    if (ctx->aws_session_token == NULL) {
         fprintf(stderr, "--aws-session-token must be set\n");
         exit(1);
     }
 
     // Check if ciphertext is set
-    if(ctx->ciphertext_b64 == NULL){
+    if (ctx->ciphertext_b64 == NULL) {
         fprintf(stderr, "--ciphertext must be set\n");
         exit(1);
     }
 
     // Set default AWS region if not specified
-    if(ctx->region == NULL){
+    if (ctx->region == NULL) {
         ctx->region = aws_string_new_from_c_str(ctx->allocator, DEFAULT_REGION);
     }
 }
@@ -154,18 +154,14 @@ static void decrypt(struct app_ctx *app_ctx, struct aws_byte_buf *ciphertext_dec
     /* Parent is always on CID 3 */
     struct aws_socket_endpoint endpoint = {.address = DEFAULT_PARENT_CID, .port = app_ctx->proxy_port};
     struct aws_nitro_enclaves_kms_client_configuration configuration = {
-        .allocator = app_ctx->allocator,
-        .endpoint = &endpoint,
-        .domain = AWS_SOCKET_VSOCK,
-        .region = app_ctx->region
-    };
+        .allocator = app_ctx->allocator, .endpoint = &endpoint, .domain = AWS_SOCKET_VSOCK, .region = app_ctx->region};
 
     /* Sets the AWS credentials and creates a KMS client with them. */
     struct aws_credentials *new_credentials = aws_credentials_new(
         app_ctx->allocator,
-        aws_byte_cursor_from_c_str((const char*) app_ctx->aws_access_key_id->bytes),
-        aws_byte_cursor_from_c_str((const char*) app_ctx->aws_secret_access_key->bytes),
-        aws_byte_cursor_from_c_str((const char*) app_ctx->aws_session_token->bytes),
+        aws_byte_cursor_from_c_str((const char *)app_ctx->aws_access_key_id->bytes),
+        aws_byte_cursor_from_c_str((const char *)app_ctx->aws_secret_access_key->bytes),
+        aws_byte_cursor_from_c_str((const char *)app_ctx->aws_session_token->bytes),
         UINT64_MAX);
 
     /* If credentials or client already exists, replace them. */
@@ -177,12 +173,12 @@ static void decrypt(struct app_ctx *app_ctx, struct aws_byte_buf *ciphertext_dec
     credentials = new_credentials;
     configuration.credentials = new_credentials;
     client = aws_nitro_enclaves_kms_client_new(&configuration);
-    
+
     /* Decrypt uses KMS to decrypt the ciphertext */
     /* Get decode base64 string into bytes. */
     size_t ciphertext_len;
     struct aws_byte_buf ciphertext;
-    struct aws_byte_cursor ciphertext_b64 = aws_byte_cursor_from_c_str((const char*) app_ctx->ciphertext_b64->bytes);
+    struct aws_byte_cursor ciphertext_b64 = aws_byte_cursor_from_c_str((const char *)app_ctx->ciphertext_b64->bytes);
 
     rc = aws_base64_compute_decoded_len(&ciphertext_b64, &ciphertext_len);
     fail_on(rc != AWS_OP_SUCCESS);
@@ -239,7 +235,7 @@ int main(int argc, char **argv) {
     decrypt(&app_ctx, &ciphertext_decrypted_b64);
 
     /* Print the base64-encoded plaintext to stdout */
-    fprintf(stdout, "%s", (const char *) ciphertext_decrypted_b64.buffer);
+    fprintf(stdout, "%s", (const char *)ciphertext_decrypted_b64.buffer);
 
     aws_byte_buf_clean_up(&ciphertext_decrypted_b64);
     aws_nitro_enclaves_library_clean_up();

--- a/bin/kmstool-enclave/main.c
+++ b/bin/kmstool-enclave/main.c
@@ -147,7 +147,7 @@ struct aws_string *s_read_region(struct app_ctx *ctx, struct json_object *object
     struct json_object *aws_region = json_object_object_get(object, "AwsRegion");
     /* Neither is set, so use default_region */
     if (aws_region == NULL && ctx->region == NULL) {
-       return aws_string_clone_or_reuse(ctx->allocator, default_region);
+        return aws_string_clone_or_reuse(ctx->allocator, default_region);
     }
 
     /* Both are set, don't allow it. */
@@ -343,7 +343,7 @@ static void handle_connection(struct app_ctx *app_ctx, int peer_fd) {
             aws_byte_buf_clean_up(&ciphertext_decrypted_b64);
             break_on(rc <= 0);
         decrypt_clean_err:
-	    /* This is a fallthrough that cleans up local objects ahead of loop_next_err */
+            /* This is a fallthrough that cleans up local objects ahead of loop_next_err */
             aws_byte_buf_clean_up(&ciphertext_decrypted);
             aws_byte_buf_clean_up(&ciphertext_decrypted_b64);
             goto loop_next_err;

--- a/include/aws/nitro_enclaves/kms.h
+++ b/include/aws/nitro_enclaves/kms.h
@@ -940,7 +940,8 @@ int aws_kms_encrypt_blocking(
  * @param[in]   key_spec     The spec of key to generate: an AES128 or an AES256 key.
  * @param[out]  plaintext    The plaintext output of the call. Should be an empty, but non-null aws_byte_buf.
  * @param[out]  ciphertext_blob The ciphertext blob output of the call. Should be an empty, but non-null aws_byte_buf.
- * @return                   Returns AWS_OP_SUCCESS if the call succeeds and plaintext and ciphertext_blob are populated.
+ * @return                   Returns AWS_OP_SUCCESS if the call succeeds and plaintext and ciphertext_blob are
+ *                           populated.
  */
 AWS_NITRO_ENCLAVES_API
 int aws_kms_generate_data_key_blocking(

--- a/include/aws/nitro_enclaves/nitro_enclaves.h
+++ b/include/aws/nitro_enclaves/nitro_enclaves.h
@@ -7,26 +7,26 @@
  */
 
 /**
-  * @mainpage
-  *
-  * # AWS Nitro Enclaves SDK for C
-  *
-  * This SDK allows you to use the functionality of AWS Nitro Enclaves and provides simple APIs for seeding
-  * system entropy or calling into AWS KMS using attestation.
-  *
-  * To instantiate the library, call aws_nitro_enclaves_library_init() first.
-  * To seed entropy, use aws_nitro_enclaves_library_seed_entropy().
-  *
-  * ## AWS KMS
-  * To use AWS KMS functionality, create an aws_kms_client using aws_nitro_enclaves_kms_client_new(),
-  * afterwards, call aws_kms_decrypt_blocking(), aws_kms_generate_random_blocking() and
-  * aws_kms_generate_data_key_blocking(), depending on needs.
-  * 
-  * Additional documentation and sample can be found in the main
-  * [Github repository](https://github.com/aws/aws-nitro-enclaves-sdk-c) or
-  * on AWS documentation website for
-  * [AWS Nitro Enclaves](https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave.html)
-  */
+ * @mainpage
+ *
+ * # AWS Nitro Enclaves SDK for C
+ *
+ * This SDK allows you to use the functionality of AWS Nitro Enclaves and provides simple APIs for seeding
+ * system entropy or calling into AWS KMS using attestation.
+ *
+ * To instantiate the library, call aws_nitro_enclaves_library_init() first.
+ * To seed entropy, use aws_nitro_enclaves_library_seed_entropy().
+ *
+ * ## AWS KMS
+ * To use AWS KMS functionality, create an aws_kms_client using aws_nitro_enclaves_kms_client_new(),
+ * afterwards, call aws_kms_decrypt_blocking(), aws_kms_generate_random_blocking() and
+ * aws_kms_generate_data_key_blocking(), depending on needs.
+ *
+ * Additional documentation and sample can be found in the main
+ * [Github repository](https://github.com/aws/aws-nitro-enclaves-sdk-c) or
+ * on AWS documentation website for
+ * [AWS Nitro Enclaves](https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave.html)
+ */
 
 #include <aws/nitro_enclaves/exports.h>
 
@@ -34,9 +34,9 @@
 #include <aws/common/macros.h>
 
 /**
-  * @file
-  * Initialize the library and main enclave functionality.
-  */
+ * @file
+ * Initialize the library and main enclave functionality.
+ */
 
 AWS_EXTERN_C_BEGIN
 

--- a/include/aws/vsock/VirtioVsock.h
+++ b/include/aws/vsock/VirtioVsock.h
@@ -6,35 +6,35 @@
  */
 
 #ifndef VIRTIOVSOCK_H
-#define VIRTIOVSOCK_H
+#    define VIRTIOVSOCK_H
 
-#include <WinSock2.h>
+#    include <WinSock2.h>
 
-#define VSOCK_PROVIDER_NAME             "AWS VirtIO Vsock Provider"
-#define VSOCK_PROVIDER_WNAME            L"AWS VirtIO Vsock Provider"
+#    define VSOCK_PROVIDER_NAME "AWS VirtIO Vsock Provider"
+#    define VSOCK_PROVIDER_WNAME L"AWS VirtIO Vsock Provider"
 
-// This family is not reserved on Microsoft Windows.  Given that it is 
-// in use in multiple public projects and other operating systems, it is 
-// likely that the purpose of this family will not be assigned to other 
+// This family is not reserved on Microsoft Windows.  Given that it is
+// in use in multiple public projects and other operating systems, it is
+// likely that the purpose of this family will not be assigned to other
 // purposes by Windows.
-#ifndef AF_VSOCK
-#define AF_VSOCK                        40
-#endif
+#    ifndef AF_VSOCK
+#        define AF_VSOCK 40
+#    endif
 
-#define SOCKADDR_VM_CID_ANY             (~0U)
-#define SOCKADDR_VM_PORT_ANY            (0U)
+#    define SOCKADDR_VM_CID_ANY (~0U)
+#    define SOCKADDR_VM_PORT_ANY (0U)
 
-#define SOCKADDR_VM_CID_HYPERVISOR      0
-#define SOCKADDR_VM_CID_RESERVED        1
-#define SOCKADDR_VM_CID_HOST            2
+#    define SOCKADDR_VM_CID_HYPERVISOR 0
+#    define SOCKADDR_VM_CID_RESERVED 1
+#    define SOCKADDR_VM_CID_HOST 2
 
 // Defined to be compatible with the Linux sockaddr_vm struct from the Linux
 // man pages.
 struct sockaddr_vm {
     u_short svm_family;
     u_short svm_reserved1;
-    u_int   svm_port;
-    u_int   svm_cid;
+    u_int svm_port;
+    u_int svm_cid;
 };
 typedef struct sockaddr_vm SOCKADDR_VM, *PSOCKADDR_VM;
 

--- a/source/rest.c
+++ b/source/rest.c
@@ -71,11 +71,11 @@ struct aws_nitro_enclaves_rest_client *aws_nitro_enclaves_rest_client_new(
 
     char host_name_str[256];
     snprintf(
-       host_name_str,
-       sizeof(host_name_str),
-       "%s.%s.amazonaws.com",
-       aws_string_c_str(configuration->service),
-       aws_string_c_str(configuration->region));
+        host_name_str,
+        sizeof(host_name_str),
+        "%s.%s.amazonaws.com",
+        aws_string_c_str(configuration->service),
+        aws_string_c_str(configuration->region));
     struct aws_byte_cursor host_name = aws_byte_cursor_from_c_str(host_name_str);
 
     struct aws_nitro_enclaves_rest_client *rest_client =
@@ -127,8 +127,7 @@ struct aws_nitro_enclaves_rest_client *aws_nitro_enclaves_rest_client_new(
     aws_tls_ctx_options_clean_up(&tls_ctx_options);
 
     aws_tls_connection_options_init_from_ctx(&tls_connection_options, rest_client->tls_ctx);
-    if (aws_tls_connection_options_set_server_name(
-            &tls_connection_options, rest_client->allocator, &host_name)) {
+    if (aws_tls_connection_options_set_server_name(&tls_connection_options, rest_client->allocator, &host_name)) {
         // TODO: aws_raise
         goto err_clean;
     }
@@ -332,12 +331,13 @@ static struct aws_http_message *s_make_request(
 
     struct aws_http_message *request = aws_http_message_new_request(rest_client->allocator);
 
-    struct aws_http_header host_header = {.name = aws_byte_cursor_from_c_str("host"),
-                                          .value = aws_byte_cursor_from_string(rest_client->host_name)};
+    struct aws_http_header host_header = {
+        .name = aws_byte_cursor_from_c_str("host"), .value = aws_byte_cursor_from_string(rest_client->host_name)};
     aws_http_message_add_header(request, host_header);
 
-    struct aws_http_header content_type = {.name = aws_byte_cursor_from_c_str("content-type"),
-                                           .value = aws_byte_cursor_from_c_str("application/x-amz-json-1.1")};
+    struct aws_http_header content_type = {
+        .name = aws_byte_cursor_from_c_str("content-type"),
+        .value = aws_byte_cursor_from_c_str("application/x-amz-json-1.1")};
     aws_http_message_add_header(request, content_type);
 
     struct aws_http_header target_header = {.name = aws_byte_cursor_from_c_str("x-amz-target"), .value = target};
@@ -353,8 +353,8 @@ static struct aws_http_message *s_make_request(
     aws_input_stream_get_length(request_data_stream, &content_length);
     sprintf(content_length_str, "%" PRIi64, content_length);
 
-    struct aws_http_header content_length_header = {.name = aws_byte_cursor_from_c_str("content-length"),
-                                                    .value = aws_byte_cursor_from_c_str(content_length_str)};
+    struct aws_http_header content_length_header = {
+        .name = aws_byte_cursor_from_c_str("content-length"), .value = aws_byte_cursor_from_c_str(content_length_str)};
     aws_http_message_add_header(request, content_length_header);
 
     aws_http_message_set_body_stream(request, request_data_stream);

--- a/tests/kms_test.c
+++ b/tests/kms_test.c
@@ -278,7 +278,8 @@ static int s_test_kms_decrypt_request_to_json(struct aws_allocator *allocator, v
     request->key_id = aws_string_new_from_c_str(allocator, KEY_ID);
     ASSERT_NOT_NULL(request->key_id);
 
-    struct aws_string *json = aws_string_new_from_c_str(allocator, "{ \"AttestationDocument\": \"" CIPHERTEXT_BLOB_BASE64 "\" }");
+    struct aws_string *json =
+        aws_string_new_from_c_str(allocator, "{ \"AttestationDocument\": \"" CIPHERTEXT_BLOB_BASE64 "\" }");
     ASSERT_NOT_NULL(json);
     request->recipient = aws_recipient_from_json(allocator, json);
     ASSERT_NOT_NULL(request->recipient);
@@ -1556,7 +1557,8 @@ static int s_test_kms_generate_data_key_request_to_json(struct aws_allocator *al
     ASSERT_SUCCESS(aws_array_list_push_back(&request->grant_tokens, &token_first));
     ASSERT_SUCCESS(aws_array_list_push_back(&request->grant_tokens, &token_second));
 
-    struct aws_string *json = aws_string_new_from_c_str(allocator, "{ \"AttestationDocument\": \"" CIPHERTEXT_BLOB_BASE64 "\" }");
+    struct aws_string *json =
+        aws_string_new_from_c_str(allocator, "{ \"AttestationDocument\": \"" CIPHERTEXT_BLOB_BASE64 "\" }");
     ASSERT_NOT_NULL(json);
     request->recipient = aws_recipient_from_json(allocator, json);
     ASSERT_NOT_NULL(request->recipient);
@@ -1749,7 +1751,8 @@ static int s_test_kms_generate_random_request_to_json(struct aws_allocator *allo
     request->number_of_bytes = 1;
     request->custom_key_store_id = aws_string_new_from_c_str(allocator, KEY_ID);
     ASSERT_NOT_NULL(request->custom_key_store_id);
-    struct aws_string *json = aws_string_new_from_c_str(allocator, "{ \"AttestationDocument\": \"" CIPHERTEXT_BLOB_BASE64 "\" }");
+    struct aws_string *json =
+        aws_string_new_from_c_str(allocator, "{ \"AttestationDocument\": \"" CIPHERTEXT_BLOB_BASE64 "\" }");
     ASSERT_NOT_NULL(json);
     request->recipient = aws_recipient_from_json(allocator, json);
     ASSERT_NOT_NULL(request->recipient);


### PR DESCRIPTION
The code base contains multiple coding styles,
which are hard to follow.

To ensure the same coding style as aws-c-common,
clang formatter is applied.

Signed-off-by: Alexandru Vasile <lexnv@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
