### PR TITLE
Line break in the last line of usage printing

### DIFF
--- a/bin/kmstool-enclave-cli/main.c
+++ b/bin/kmstool-enclave-cli/main.c
@@ -53,7 +53,7 @@ static void s_usage(int exit_code) {
     fprintf(stderr, "    --aws-secret-access-key SECRET_ACCESS_KEY: AWS secret access key\n");
     fprintf(stderr, "    --aws-session-token SESSION_TOKEN: Session token associated with the access key ID\n");
     fprintf(stderr, "    --ciphertext CIPHERTEXT: base64-encoded ciphertext that need to decrypt\n");
-    fprintf(stderr, "    --help: Display this message and exit");
+    fprintf(stderr, "    --help: Display this message and exit\n");
     exit(exit_code);
 }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Added a line break after printing the usage message

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
