### PR TITLE
Add Dockerfile to build on Alpine Linux (static musl binaries)

### DIFF
--- a/bin/kmstool-enclave-cli/build-musl.sh
+++ b/bin/kmstool-enclave-cli/build-musl.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+docker build --target kmstool-enclave-cli -t kmstool-enclave-cli -f ../../containers/Dockerfile.alpine ../..
+CONTAINER_ID=$(docker create kmstool-enclave-cli)
+docker cp $CONTAINER_ID:/kmstool_enclave_cli ./
+docker rm $CONTAINER_ID

--- a/containers/Dockerfile.alpine
+++ b/containers/Dockerfile.alpine
@@ -1,0 +1,109 @@
+FROM alpine:latest as builder
+
+RUN apk add cmake gcc git tar make g++ go ninja libc-dev libffi-dev openssl-dev py3-pip zlib-dev
+# These next three instructions are taken from the docker-rust dockerfiles for alpine
+RUN apk add --no-cache \
+        ca-certificates \
+        gcc
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=1.61.0
+
+RUN set -eux; \
+    apkArch="$(apk --print-arch)"; \
+    case "$apkArch" in \
+        x86_64) rustArch='x86_64-unknown-linux-musl'; rustupSha256='bdf022eb7cba403d0285bb62cbc47211f610caec24589a72af70e1e900663be9' ;; \
+        aarch64) rustArch='aarch64-unknown-linux-musl'; rustupSha256='89ce657fe41e83186f5a6cdca4e0fd40edab4fd41b0f9161ac6241d49fbdbbbe' ;; \
+        *) echo >&2 "unsupported architecture: $apkArch"; exit 1 ;; \
+    esac; \
+    url="https://static.rust-lang.org/rustup/archive/1.24.3/${rustArch}/rustup-init"; \
+    wget "$url"; \
+    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;
+
+# We keep the build artifacts in the -build directory
+WORKDIR /tmp/crt-builder
+
+RUN git clone -b v1.0.2 https://github.com/awslabs/aws-lc.git aws-lc #
+RUN cmake -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-lc -B aws-lc/build .
+RUN go env -w GOPROXY=direct
+RUN cmake --build aws-lc/build --target install
+
+RUN git clone -b v1.3.11 https://github.com/aws/s2n-tls.git
+RUN cmake -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -S s2n-tls -B s2n-tls/build
+RUN cmake --build s2n-tls/build --target install
+
+RUN git clone -b v0.6.20 https://github.com/awslabs/aws-c-common.git
+RUN cmake -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-common -B aws-c-common/build
+RUN cmake --build aws-c-common/build --target install
+
+RUN git clone -b v0.1.2 https://github.com/awslabs/aws-c-sdkutils.git
+RUN cmake -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-sdkutils -B aws-c-sdkutils/build
+RUN cmake --build aws-c-sdkutils/build --target install
+
+RUN git clone -b v0.5.17 https://github.com/awslabs/aws-c-cal.git
+RUN cmake -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-cal -B aws-c-cal/build
+RUN cmake --build aws-c-cal/build --target install
+
+RUN git clone -b v0.10.21 https://github.com/awslabs/aws-c-io.git
+RUN cmake -DUSE_VSOCK=1 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-io -B aws-c-io/build
+RUN cmake --build aws-c-io/build --target install
+
+RUN git clone -b v0.2.14 http://github.com/awslabs/aws-c-compression.git
+RUN cmake -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-compression -B aws-c-compression/build
+RUN cmake --build aws-c-compression/build --target install
+
+RUN git clone -b v0.6.13 https://github.com/awslabs/aws-c-http.git
+RUN cmake -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-http -B aws-c-http/build
+RUN cmake --build aws-c-http/build --target install
+
+RUN git clone -b v0.6.11 https://github.com/awslabs/aws-c-auth.git
+RUN cmake -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-auth -B aws-c-auth/build
+RUN cmake --build aws-c-auth/build --target install
+
+RUN git clone -b json-c-0.16-20220414 https://github.com/json-c/json-c.git
+RUN cmake -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=OFF -GNinja -S json-c -B json-c/build
+RUN cmake --build json-c/build --target install
+
+RUN git clone -b v0.2.1 https://github.com/aws/aws-nitro-enclaves-nsm-api.git
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+RUN cd aws-nitro-enclaves-nsm-api && cargo build --release -p nsm-lib
+RUN mv aws-nitro-enclaves-nsm-api/target/release/libnsm.a /usr/lib
+RUN mv aws-nitro-enclaves-nsm-api/target/release/nsm.h /usr/include
+
+RUN apk add doxygen
+COPY . aws-nitro-enclaves-sdk-c
+RUN cmake -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja \
+	-S aws-nitro-enclaves-sdk-c -B aws-nitro-enclaves-sdk-c/build
+RUN cmake --build aws-nitro-enclaves-sdk-c/build --target install
+RUN cmake --build aws-nitro-enclaves-sdk-c/build --target docs
+
+# Test
+FROM builder as test
+RUN cmake --build aws-nitro-enclaves-sdk-c/build --target test
+
+# kmstool-enclave
+FROM alpine:latest as kmstool-enclave
+COPY --from=builder /usr/bin/kmstool_enclave /kmstool_enclave
+ARG REGION
+ARG ENDPOINT
+ENV REGION=${REGION}
+ENV ENDPOINT=${ENDPOINT}
+CMD ["/kmstool_enclave"]
+
+# kmstool-instance
+FROM alpine:latest as kmstool-instance
+COPY --from=builder /usr/bin/kmstool_instance /kmstool_instance
+CMD ["/kmstool_instance"]
+
+# kmstool-enclave-cli
+FROM alpine:latest as kmstool-enclave-cli
+COPY --from=builder /usr/bin/kmstool_enclave_cli /kmstool_enclave_cli


### PR DESCRIPTION
*Description of changes:*
I am building a nitro-enclave container on Alpine Linux. Alpine uses musl instead of glibc. That means that I can't use the kmstool* binaries that are built on Amazon Linux. This PR adds a Dockerfile that can build everything in Alpine. A container that uses alpine as its base and adds the `gcompat` package can use the kmstool* binaries produced by this change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
