### PR TITLE
feat: add key_id & algorithm to kmstool-enclave-cli decrypt

### DIFF
--- a/bin/kmstool-enclave-cli/main.c
+++ b/bin/kmstool-enclave-cli/main.c
@@ -58,10 +58,10 @@ static void s_usage(int exit_code) {
     fprintf(stderr, "    --aws-secret-access-key SECRET_ACCESS_KEY: AWS secret access key\n");
     fprintf(stderr, "    --aws-session-token SESSION_TOKEN: Session token associated with the access key ID\n");
     fprintf(stderr, "    --ciphertext CIPHERTEXT: base64-encoded ciphertext that need to decrypt\n");
-    fprintf(stderr, "    --key-id KEY_ID: decrypt key id\n");
+    fprintf(stderr, "    --key-id KEY_ID: decrypt key id (for symmetric keys, is optional)\n");
     fprintf(
         stderr,
-        "    --encryption-algorithm ENCRYPTION_ALGORITHM: encryption algorhthm for ciphertext (is required at key-id "
+        "    --encryption-algorithm ENCRYPTION_ALGORITHM: encryption algorhthm for ciphertext (is required if key-id "
         "exists)\n");
     fprintf(stderr, "    --help: Display this message and exit\n");
     exit(exit_code);
@@ -162,7 +162,7 @@ static void s_parse_options(int argc, char **argv, struct app_ctx *ctx) {
     // if key id is set check encryption algorithm is exists
     if (ctx->key_id != NULL) {
         if (ctx->encryption_algorithm == NULL) {
-            fprintf(stderr, "--encryption-algorithm must be set at key-id exists\n");
+            fprintf(stderr, "--encryption-algorithm must be set if key-id exists\n");
             exit(1);
         }
     }

--- a/bin/kmstool-enclave/main.c
+++ b/bin/kmstool-enclave/main.c
@@ -323,7 +323,7 @@ static void handle_connection(struct app_ctx *app_ctx, int peer_fd) {
 
             /* Decrypt the data with KMS. */
             struct aws_byte_buf ciphertext_decrypted;
-            rc = aws_kms_decrypt_blocking(client, &ciphertext, &ciphertext_decrypted);
+            rc = aws_kms_decrypt_blocking(client, NULL, NULL, &ciphertext, &ciphertext_decrypted);
             aws_byte_buf_clean_up(&ciphertext);
             fail_on(rc != AWS_OP_SUCCESS, loop_next_err, "Could not decrypt ciphertext");
 

--- a/include/aws/nitro_enclaves/kms.h
+++ b/include/aws/nitro_enclaves/kms.h
@@ -972,8 +972,8 @@ void aws_nitro_enclaves_kms_client_destroy(struct aws_nitro_enclaves_kms_client 
  * Calling it from a non-enclave environment will fail.
  *
  * @param[in]   client                  The AWS KMS client to use for calling the API.
- * @param[in]   key_id                  The ARN or alias of AWS KMS CMK used to encrypt the data key.
- * @param[in]   encryption_algorithm    The encryption algorithm that will be used to decrypt the ciphertext.
+ * @param[in]   key_id                  The ARN or alias of AWS KMS CMK used to encrypt the data key. (For symmetric keys, set key_id and encryption_algorithm to NULL as the ciphertext may contain key-id)
+ * @param[in]   encryption_algorithm    The encryption algorithm that will be used to decrypt the ciphertext. (For symmetric keys, set key_id and encryption_algorithm to NULL as the ciphertext may contain key-id)
  * @param[in]   ciphertext              The ciphertext to decrypt.
  * @param[out]  plaintext               The plaintext output of the call. Should be an empty, but non-null aws_byte_buf.
  * @return

--- a/include/aws/nitro_enclaves/kms.h
+++ b/include/aws/nitro_enclaves/kms.h
@@ -971,14 +971,18 @@ void aws_nitro_enclaves_kms_client_destroy(struct aws_nitro_enclaves_kms_client 
  * This function generates an Attestation Document and calls AWS KMS with enclave-specific parameters.
  * Calling it from a non-enclave environment will fail.
  *
- * @param[in]   client      The AWS KMS client to use for calling the API.
- * @param[in]   ciphertext  The ciphertext to decrypt.
- * @param[out]  plaintext   The plaintext output of the call. Should be an empty, but non-null aws_byte_buf.
- * @return                  Returns AWS_OP_SUCCESS if the call succeeds and plaintext is populated.
+ * @param[in]   client                  The AWS KMS client to use for calling the API.
+ * @param[in]   key_id                  The ARN or alias of AWS KMS CMK used to encrypt the data key.
+ * @param[in]   encryption_algorithm    The encryption algorithm that will be used to decrypt the ciphertext.
+ * @param[in]   ciphertext              The ciphertext to decrypt.
+ * @param[out]  plaintext               The plaintext output of the call. Should be an empty, but non-null aws_byte_buf.
+ * @return
  */
 AWS_NITRO_ENCLAVES_API
 int aws_kms_decrypt_blocking(
     struct aws_nitro_enclaves_kms_client *client,
+    const struct aws_string *key_id,
+    const struct aws_string *encryption_algorithm,
     const struct aws_byte_buf *ciphertext,
     struct aws_byte_buf *plaintext /* TODO: err_reason */);
 


### PR DESCRIPTION
Modified to accept key-id and encryption-algorithm in aws_kms_decrypt_blocking API so that kmstool-enclave-cli can support kms rsa decryption.