### PR TITLE
kmstool-enclave-cli add back support for --key-id

### DIFF
--- a/bin/kmstool-enclave-cli/main.c
+++ b/bin/kmstool-enclave-cli/main.c
@@ -183,7 +183,9 @@ static void s_parse_options(int argc, char **argv, const char *subcommand, struc
                          case 'a':
                             ctx->encryption_algorithm = aws_string_new_from_c_str(ctx->allocator, aws_cli_optarg);
                             break;
-
+                         case 'K':
+                            ctx->key_id = aws_string_new_from_c_str(ctx->allocator, aws_cli_optarg);
+                            break;
                         default:
                             fprintf(stderr, "Unknown option: %s\n", aws_cli_optarg);
                             s_usage_decrypt(1);


### PR DESCRIPTION
*Please see:* https://github.com/aws/aws-nitro-enclaves-sdk-c/pull/85

*Description of changes:*
kmstool-enclave-cli add back support for --key-id

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
