### PR TITLE
Added troubleshooting section to kmstool-enclave-cli readme

### DIFF
--- a/bin/kmstool-enclave-cli/README.md
+++ b/bin/kmstool-enclave-cli/README.md
@@ -70,3 +70,17 @@ By doing that, this tool can be used by any programming langauge that can intera
 
    plaintext = proc.communicate()[0].decode()
    ```
+
+## Troubleshooting
+
+### Missing Common CA Certificates
+If you are running `kmstool-enclave-cli` in an environment that does not have the common CA certificates installed, you will face the following error:
+```shell
+[ERROR] [2023-02-23T15:16:21Z] [00007efd15f94840] [tls-handler] - ctx: configuration error: Error initializing trust store (Error encountered in /tmp/crt-builder/s2n-tls/tls/s2n_x509_validator.c:120)
+[ERROR] [2023-02-23T15:16:21Z] [00007efd15f94840] [tls-handler] - Failed to set ca_path: (null) and ca_file (null)
+```
+
+To solve the problem, use an docker image that has common C certificates pre-installed like `amazonlinux:2`. If you want to use a docker image with a smaller initial footprint, e.g. `debian:buster-slim`, you have to install the CA certificates during the docker build step similar to this:
+```shell
+RUN apt-get update && apt-get install -y ca-certificates
+```


### PR DESCRIPTION
*Issue #, if available:*
`kmstool-enclave-cli` throws exception if common CA certs are not available in environment

*Description of changes:*
Added brief description of how to solve missing CA certs issue


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
