### PR TITLE
containers: Fallback to the older releases for some deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ This project is licensed under the Apache-2.0 License.
 |----------------------------|----------------------|---------------------------------------------------|
 | aws-lc                     | v1.12.0              | https://github.com/awslabs/aws-lc/                |
 | s2n-tls                    | v1.3.46              | https://github.com/aws/s2n-tls.git                |
-| aws-c-common               | v0.8.23              | https://github.com/awslabs/aws-c-common           |
-| aws-c-sdkutils             | v0.1.11              | https://github.com/awslabs/aws-c-sdkutils         |
-| aws-c-io                   | v0.13.26             | https://github.com/awslabs/aws-c-io               |
-| aws-c-compression          | v0.2.17              | https://github.com/awslabs/aws-c-compression      |
+| aws-c-common               | v0.8.0               | https://github.com/awslabs/aws-c-common           |
+| aws-c-sdkutils             | v0.1.2               | https://github.com/awslabs/aws-c-sdkutils         |
+| aws-c-io                   | v0.11.0              | https://github.com/awslabs/aws-c-io               |
+| aws-c-compression          | v0.2.14              | https://github.com/awslabs/aws-c-compression      |
 | aws-c-http                 | v0.7.6               | https://github.com/awslabs/aws-c-http             |
-| aws-c-cal                  | v0.5.27              | https://github.com/awslabs/aws-c-cal              |
-| aws-c-auth                 | v0.7.0               | https://github.com/awslabs/aws-c-auth             |
+| aws-c-cal                  | v0.5.18              | https://github.com/awslabs/aws-c-cal              |
+| aws-c-auth                 | v6.15.0              | https://github.com/awslabs/aws-c-auth             |
 | aws-nitro-enclaves-nsm-api | v0.4.0               | https://github.com/aws/aws-nitro-enclaves-nsm-api |
 | json-c                     | json-c-0.16-20220414 | https://github.com/json-c/json-c                  |
 

--- a/containers/Dockerfile.al2
+++ b/containers/Dockerfile.al2
@@ -30,23 +30,23 @@ RUN git clone --depth 1 -b v1.3.46 https://github.com/aws/s2n-tls.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DBUILD_TESTING=0 -DCMAKE_INSTALL_PREFIX=/usr -S s2n-tls -B s2n-tls/build
 RUN cmake3 --build s2n-tls/build --parallel $(nproc) --target install
 
-RUN git clone --depth 1 -b v0.8.23 https://github.com/awslabs/aws-c-common.git
+RUN git clone --depth 1 -b v0.8.0 https://github.com/awslabs/aws-c-common.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DBUILD_TESTING=0 -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-common -B aws-c-common/build
 RUN cmake3 --build aws-c-common/build --parallel $(nproc) --target install
 
-RUN git clone --depth 1 -b v0.1.11 https://github.com/awslabs/aws-c-sdkutils.git
+RUN git clone --depth 1 -b v0.1.2 https://github.com/awslabs/aws-c-sdkutils.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DBUILD_TESTING=0 -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-sdkutils -B aws-c-sdkutils/build
 RUN cmake3 --build aws-c-sdkutils/build --parallel $(nproc) --target install
 
-RUN git clone --depth 1 -b v0.5.27 https://github.com/awslabs/aws-c-cal.git
+RUN git clone --depth 1 -b v0.5.18 https://github.com/awslabs/aws-c-cal.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DBUILD_TESTING=0 -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-cal -B aws-c-cal/build
 RUN cmake3 --build aws-c-cal/build --parallel $(nproc) --target install
 
-RUN git clone --depth 1 -b v0.13.26 https://github.com/awslabs/aws-c-io.git
+RUN git clone --depth 1 -b v0.11.0 https://github.com/awslabs/aws-c-io.git
 RUN cmake3 -DUSE_VSOCK=1 -DCMAKE_PREFIX_PATH=/usr -DBUILD_TESTING=0 -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-io -B aws-c-io/build
 RUN cmake3 --build aws-c-io/build --parallel $(nproc) --target install
 
-RUN git clone --depth 1 -b v0.2.17 http://github.com/awslabs/aws-c-compression.git
+RUN git clone --depth 1 -b v0.2.14 http://github.com/awslabs/aws-c-compression.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DBUILD_TESTING=0 -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-compression -B aws-c-compression/build
 RUN cmake3 --build aws-c-compression/build --parallel $(nproc) --target install
 
@@ -54,7 +54,7 @@ RUN git clone --depth 1 -b v0.7.6 https://github.com/awslabs/aws-c-http.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DBUILD_TESTING=0 -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-http -B aws-c-http/build
 RUN cmake3 --build aws-c-http/build --parallel $(nproc) --target install
 
-RUN git clone --depth 1 -b v0.7.0 https://github.com/awslabs/aws-c-auth.git
+RUN git clone --depth 1 -b v0.6.15 https://github.com/awslabs/aws-c-auth.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DBUILD_TESTING=0 -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-auth -B aws-c-auth/build
 RUN cmake3 --build aws-c-auth/build --parallel $(nproc) --target install
 


### PR DESCRIPTION
Newer aws-c-io versions after v0.11.0 create run-time issues due to a limitation described here:
https://github.com/awslabs/aws-c-io/issues/576

We need to fallback to the older version of aws-c-io until this limitation gets addressed and solved.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
