### PR TITLE
Update AmazonLinux to 2023

### DIFF
--- a/bin/kmstool-enclave-cli/README.md
+++ b/bin/kmstool-enclave-cli/README.md
@@ -137,7 +137,7 @@ If you are running `kmstool-enclave-cli` in an environment that does not have th
 [ERROR] [2023-02-23T15:16:21Z] [00007efd15f94840] [tls-handler] - Failed to set ca_path: (null) and ca_file (null)
 ```
 
-To solve the problem, use a docker image that has common CA certificates pre-installed like `amazonlinux:2`. [`kmstool-enclave`](https://github.com/aws/aws-nitro-enclaves-sdk-c/blob/main/docs/kmstool.md) explicitly gets the common CA certificates [installed during the build process](https://github.com/aws/aws-nitro-enclaves-sdk-c/blob/main/containers/Dockerfile.al2#L90) to enable a minimal enclave build from [`scratch`](https://docs.docker.com/build/building/base-images/#create-a-simple-parent-image-using-scratch).
+To solve the problem, use a docker image that has common CA certificates pre-installed like `amazonlinux:2023`. [`kmstool-enclave`](https://github.com/aws/aws-nitro-enclaves-sdk-c/blob/main/docs/kmstool.md) explicitly gets the common CA certificates [installed during the build process](https://github.com/aws/aws-nitro-enclaves-sdk-c/blob/main/containers/Dockerfile.al2#L90) to enable a minimal enclave build from [`scratch`](https://docs.docker.com/build/building/base-images/#create-a-simple-parent-image-using-scratch).
 
 If you want to use a generic docker image with a smaller initial footprint, e.g. `debian:buster-slim`, you have to install the CA certificates during the docker build step similar to this:
 ```shell

--- a/containers/Dockerfile.al2
+++ b/containers/Dockerfile.al2
@@ -1,7 +1,7 @@
 # Copyright 2020-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG BASE_IMAGE=public.ecr.aws/amazonlinux/amazonlinux:2
+ARG BASE_IMAGE=public.ecr.aws/amazonlinux/amazonlinux:2023
 
 FROM $BASE_IMAGE as builder
 


### PR DESCRIPTION
*[Issue #124](https://github.com/aws/aws-nitro-enclaves-sdk-c/issues/124): Update to AmazonLinux 2023*

*Description of changes:*
Update to AmazonLinux 2023

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
