### PR TITLE
Update rust toolchain to fix build issue in 0.2.1

### DIFF
--- a/containers/Dockerfile.al2
+++ b/containers/Dockerfile.al2
@@ -4,7 +4,7 @@ RUN yum upgrade -y
 RUN amazon-linux-extras enable epel
 RUN yum clean -y metadata && yum install -y epel-release
 RUN yum install -y cmake3 gcc git tar make
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.60
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.63
 
 RUN yum install -y gcc-c++
 RUN yum install -y go


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Build is failing in 0.2.1.  Try updating rust toolchain to fix the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
