### PR TITLE
Update to rust 1.63 toolchain to fix build

### DIFF
--- a/containers/Dockerfile.al2
+++ b/containers/Dockerfile.al2
@@ -4,7 +4,7 @@ RUN yum upgrade -y
 RUN amazon-linux-extras enable epel
 RUN yum clean -y metadata && yum install -y epel-release
 RUN yum install -y cmake3 gcc git tar make
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.60
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.63
 
 RUN yum install -y gcc-c++
 RUN yum install -y go

--- a/containers/Dockerfile.al2
+++ b/containers/Dockerfile.al2
@@ -1,4 +1,4 @@
-FROM amazonlinux as builder
+FROM amazonlinux:2 as builder
 
 RUN yum upgrade -y
 RUN amazon-linux-extras enable epel


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, the `0.2.1` version doesn't build because of two issues:
* `amazon-linux-extras` is not present in Amazon Linux 2023 which is used by default to build using docker, which results in a build error
* The rust toolchain doesn't build with the current version: `1.60`
This PR addresses this issues by:
* Fixing the base image to AL2
* Updating to build with rust `1.63`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
