### PR TITLE
Update kmstool documentation

### DIFF
--- a/docs/kmstool.md
+++ b/docs/kmstool.md
@@ -291,7 +291,7 @@ Back on the first terminal session where you [encrypted the test message](#encry
 CMK_REGION=us-east-1 # Must match above
 ENCLAVE_CID=$(nitro-cli describe-enclaves | jq -r .[0].EnclaveCID)
 # Run docker with network host to allow it to fetch IAM credentials with IMDSv2
-docker run --network host -it kmstool-instance \
+docker run --network host --security-opt seccomp=unconfined -it kmstool-instance \
     /kmstool_instance --cid "$ENCLAVE_CID" --region "$CMK_REGION" "$CIPHERTEXT"
 ```
 PowerShell:


### PR DESCRIPTION
Since Docker 24.x `socket` syscall for `vsock` argument is restricted through seccomp rules by default: https://github.com/moby/moby/pull/44562

It should be safe to lift those seccomp restrictions completely with a dedicated flag when launching container on parent instance. Container is not used for isolation here, but more for reproducible environment.


*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
