### PR TITLE
Update dependency list

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@ This project is licensed under the Apache-2.0 License.
 ## Dependencies
 | name                       | version              | link                                              |
 |----------------------------|----------------------|---------------------------------------------------|
-| aws-lc                     | v1.12.0              | https://github.com/awslabs/aws-lc/                |
-| s2n-tls                    | v1.3.46              | https://github.com/aws/s2n-tls.git                |
-| aws-c-common               | v0.8.0               | https://github.com/awslabs/aws-c-common           |
-| aws-c-sdkutils             | v0.1.2               | https://github.com/awslabs/aws-c-sdkutils         |
-| aws-c-io                   | v0.11.0              | https://github.com/awslabs/aws-c-io               |
-| aws-c-compression          | v0.2.14              | https://github.com/awslabs/aws-c-compression      |
-| aws-c-http                 | v0.7.6               | https://github.com/awslabs/aws-c-http             |
-| aws-c-cal                  | v0.5.18              | https://github.com/awslabs/aws-c-cal              |
-| aws-c-auth                 | v6.15.0              | https://github.com/awslabs/aws-c-auth             |
+| aws-lc                     | v1.17.4              | https://github.com/awslabs/aws-lc/                |
+| s2n-tls                    | v1.4.0               | https://github.com/aws/s2n-tls.git                |
+| aws-c-common               | v0.9.12              | https://github.com/awslabs/aws-c-common           |
+| aws-c-sdkutils             | v0.1.15              | https://github.com/awslabs/aws-c-sdkutils         |
+| aws-c-io                   | v0.14.0              | https://github.com/awslabs/aws-c-io               |
+| aws-c-compression          | v0.2.18              | https://github.com/awslabs/aws-c-compression      |
+| aws-c-http                 | v0.8.0               | https://github.com/awslabs/aws-c-http             |
+| aws-c-cal                  | v0.6.15               | https://github.com/awslabs/aws-c-cal              |
+| aws-c-auth                 | v0.7.10              | https://github.com/awslabs/aws-c-auth             |
 | aws-nitro-enclaves-nsm-api | v0.4.0               | https://github.com/aws/aws-nitro-enclaves-nsm-api |
-| json-c                     | json-c-0.16-20220414 | https://github.com/json-c/json-c                  |
+| json-c                     | json-c-0.17-20230812 | https://github.com/json-c/json-c                  |
 
 ## Building
 

--- a/containers/Dockerfile.al2
+++ b/containers/Dockerfile.al2
@@ -21,44 +21,44 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-too
 # We keep the build artifacts in the -build directory
 WORKDIR /tmp/crt-builder
 
-RUN git clone --depth 1 -b v1.12.0 https://github.com/awslabs/aws-lc.git aws-lc
+RUN git clone --depth 1 -b v1.17.4 https://github.com/awslabs/aws-lc.git aws-lc
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DCMAKE_INSTALL_PREFIX=/usr -GNinja -DBUILD_TESTING=0 -S aws-lc -B aws-lc/build .
 RUN go env -w GOPROXY=direct
 RUN cmake3 --build aws-lc/build --parallel $(nproc) --target install
 
-RUN git clone --depth 1 -b v1.3.46 https://github.com/aws/s2n-tls.git
+RUN git clone --depth 1 -b v1.4.0 https://github.com/aws/s2n-tls.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DBUILD_TESTING=0 -DCMAKE_INSTALL_PREFIX=/usr -S s2n-tls -B s2n-tls/build
 RUN cmake3 --build s2n-tls/build --parallel $(nproc) --target install
 
-RUN git clone --depth 1 -b v0.8.0 https://github.com/awslabs/aws-c-common.git
+RUN git clone --depth 1 -b v0.9.12 https://github.com/awslabs/aws-c-common.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DBUILD_TESTING=0 -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-common -B aws-c-common/build
 RUN cmake3 --build aws-c-common/build --parallel $(nproc) --target install
 
-RUN git clone --depth 1 -b v0.1.2 https://github.com/awslabs/aws-c-sdkutils.git
+RUN git clone --depth 1 -b v0.1.15 https://github.com/awslabs/aws-c-sdkutils.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DBUILD_TESTING=0 -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-sdkutils -B aws-c-sdkutils/build
 RUN cmake3 --build aws-c-sdkutils/build --parallel $(nproc) --target install
 
-RUN git clone --depth 1 -b v0.5.18 https://github.com/awslabs/aws-c-cal.git
+RUN git clone --depth 1 -b v0.6.15 https://github.com/awslabs/aws-c-cal.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DBUILD_TESTING=0 -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-cal -B aws-c-cal/build
 RUN cmake3 --build aws-c-cal/build --parallel $(nproc) --target install
 
-RUN git clone --depth 1 -b v0.11.0 https://github.com/awslabs/aws-c-io.git
+RUN git clone --depth 1 -b v0.14.0 https://github.com/awslabs/aws-c-io.git
 RUN cmake3 -DUSE_VSOCK=1 -DCMAKE_PREFIX_PATH=/usr -DBUILD_TESTING=0 -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-io -B aws-c-io/build
 RUN cmake3 --build aws-c-io/build --parallel $(nproc) --target install
 
-RUN git clone --depth 1 -b v0.2.14 http://github.com/awslabs/aws-c-compression.git
+RUN git clone --depth 1 -b v0.2.18 http://github.com/awslabs/aws-c-compression.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DBUILD_TESTING=0 -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-compression -B aws-c-compression/build
 RUN cmake3 --build aws-c-compression/build --parallel $(nproc) --target install
 
-RUN git clone --depth 1 -b v0.7.6 https://github.com/awslabs/aws-c-http.git
+RUN git clone --depth 1 -b v0.8.0 https://github.com/awslabs/aws-c-http.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DBUILD_TESTING=0 -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-http -B aws-c-http/build
 RUN cmake3 --build aws-c-http/build --parallel $(nproc) --target install
 
-RUN git clone --depth 1 -b v0.6.15 https://github.com/awslabs/aws-c-auth.git
+RUN git clone --depth 1 -b v0.7.10 https://github.com/awslabs/aws-c-auth.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DBUILD_TESTING=0 -DCMAKE_INSTALL_PREFIX=/usr -GNinja -S aws-c-auth -B aws-c-auth/build
 RUN cmake3 --build aws-c-auth/build --parallel $(nproc) --target install
 
-RUN git clone --depth 1 -b json-c-0.16-20220414 https://github.com/json-c/json-c.git
+RUN git clone --depth 1 -b json-c-0.17-20230812 https://github.com/json-c/json-c.git
 RUN cmake3 -DCMAKE_PREFIX_PATH=/usr -DBUILD_TESTING=0 -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=OFF -GNinja -S json-c -B json-c/build
 RUN cmake3 --build json-c/build --parallel $(nproc)  --target install
 


### PR DESCRIPTION
Release [v0.4.1](https://github.com/aws/aws-nitro-enclaves-sdk-c/releases/tag/v0.4.1) at commit [550f731](https://github.com/aws/aws-nitro-enclaves-sdk-c/commit/550f7313bf792bf03200c7c6e1ac3fd7d2dc382f) (PR [#121](https://github.com/aws/aws-nitro-enclaves-sdk-c/pull/121)) pinned the version of [awslabs/aws-c-io@v0.11.0](https://github.com/awslabs/aws-c-io/releases/tag/v0.11.0).

This issue was reported in this project in Issue [#122](https://github.com/aws/aws-nitro-enclaves-sdk-c/issues/122) and upstream in Issue [awslabs/aws-c-io#576](https://github.com/awslabs/aws-c-io/issues/576).

**Fixed versions**

Issue [awslabs/aws-c-io#576](https://github.com/awslabs/aws-c-io/issues/576) was fixed in [awslabs/aws-c-io#613](https://github.com/awslabs/aws-c-io/pull/613). The fix commit [749c87e](https://github.com/awslabs/aws-c-io/commit/749c87e551465ff1a3c2e8a77b1181bccff2f4b6) was first released in [v0.14.0](https://github.com/awslabs/aws-c-io/releases/tag/v0.14.0).

There were a further 3 cascading changes.

1. PR [awslabs/aws-c-common#1079](https://github.com/awslabs/aws-c-common/pull/1079) where fix commit [8eaa098](https://github.com/awslabs/aws-c-common/commit/8eaa0986ad3cfd46c87432a2e4c8ab81a786085f) was first released in [v0.9.12](https://github.com/awslabs/aws-c-common/releases/tag/v0.9.12).
2. PR [awslabs/aws-c-http#457](https://github.com/awslabs/aws-c-http/pull/457) where fix commit [6a1c157](https://github.com/awslabs/aws-c-http/commit/6a1c157c20640a607102738909e89561a41e91e9) was first released in [v0.8.0](https://github.com/awslabs/aws-c-http/releases/tag/v0.8.0).
3. PR [awslabs/aws-c-auth#220](https://github.com/awslabs/aws-c-auth/pull/220) where fix commit [6ba7a0f](https://github.com/awslabs/aws-c-auth/commit/6ba7a0f8688c713dfe137716dbd5be324c2315b0) was first released in [v0.7.10](https://github.com/awslabs/aws-c-auth/releases/tag/v0.7.10)

---

**Remaining changes**

[awslabs/aws-c-sdkutils](https://github.com/awslabs/aws-c-sdkutils) was at [v0.1.2](https://github.com/awslabs/aws-c-sdkutils/releases/tag/v0.1.2). The latest compatible patch release is [v0.1.15](https://github.com/awslabs/aws-c-sdkutils/releases/tag/v0.1.15). The next patch release [v0.1.16](https://github.com/awslabs/aws-c-sdkutils/releases/tag/v0.1.16) breaks due to paired changes in [awslabs/aws-c-sdkutils#39](https://github.com/awslabs/aws-c-sdkutils/pull/39) and [awslabs/aws-c-common#1105](https://github.com/awslabs/aws-c-common/pull/1105).

[awslabs/aws-c-compression](https://github.com/awslabs/aws-c-compression) was at [v0.2.14](https://github.com/awslabs/aws-c-compression/releases/tag/v0.2.14). The latest patch release is [v0.2.18](https://github.com/awslabs/aws-c-compression/releases/tag/v0.2.18).

[awslabs/aws-c-cal](https://github.com/awslabs/aws-c-cal) was at [v0.5.18](https://github.com/awslabs/aws-c-cal/releases/tag/v0.5.18). Linking compatibility now requires at least [v0.6.0](https://github.com/awslabs/aws-c-cal/releases/tag/v0.6.0) due dependencies on the changes in [awslabs/aws-c-cal#152](https://github.com/awslabs/aws-c-cal/pull/152). The latest patch release is [v0.6.15](https://github.com/awslabs/aws-c-cal/releases/tag/v0.6.15).

[aws/s2n-tls](https://github.com/aws/s2n-tls) was at [v1.3.46](https://github.com/aws/s2n-tls/releases/tag/v1.3.46). At [v1.4.0](https://github.com/aws/s2n-tls/releases/tag/v1.4.0) it changed its version pinning for [aws/aws-lc](https://github.com/aws/aws-lc) to [v1.17.4](https://github.com/aws/aws-lc/releases/tag/v1.17.4).

The latest release of [json-c](https://github.com/json-c/json-c) is [json-c-0.17-20230812](https://github.com/json-c/json-c/releases/tag/json-c-0.17-20230812).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
