### PR TITLE
Add API to add context to Encrypt/Decrypt requests

### DIFF
--- a/include/aws/nitro_enclaves/kms.h
+++ b/include/aws/nitro_enclaves/kms.h
@@ -993,6 +993,29 @@ int aws_kms_decrypt_blocking(
  * Calling it from a non-enclave environment will fail.
  *
  * @param[in]   client                  The AWS KMS client to use for calling the API.
+ * @param[in]   key_id                  The ARN or alias of AWS KMS CMK used to encrypt the data key. (For symmetric keys, set key_id and encryption_algorithm to NULL as the ciphertext may contain key-id)
+ * @param[in]   encryption_algorithm    The encryption algorithm that will be used to decrypt the ciphertext. (For symmetric keys, set key_id and encryption_algorithm to NULL as the ciphertext may contain key-id)
+ * @param[in]   ciphertext              The ciphertext to decrypt.
+ * @param[in]   encryption_context      Optional string containing a valid JSON with [Encryption context](https://docs.aws.amazon.com/kms/latest/developerguide/encrypt_context.html) to be added to the request.
+ * @param[out]  plaintext               The plaintext output of the call. Should be an empty, but non-null aws_byte_buf.
+ * @return                              Returns AWS_OP_SUCCESS if the call succeeds and plaintext is populated.
+ */
+AWS_NITRO_ENCLAVES_API
+int aws_kms_decrypt_blocking_with_context(
+    struct aws_nitro_enclaves_kms_client *client,
+    const struct aws_string *key_id,
+    const struct aws_string *encryption_algorithm,
+    const struct aws_byte_buf *ciphertext,
+    const struct aws_string *encryption_context,
+    struct aws_byte_buf *plaintext);
+
+/**
+ * Call [AWS KMS Decrypt API](https://docs.aws.amazon.com/kms/latest/APIReference/API_Decrypt.html).
+ * This function blocks and waits for the reply.
+ * This function generates an Attestation Document and calls AWS KMS with enclave-specific parameters.
+ * Calling it from a non-enclave environment will fail.
+ *
+ * @param[in]   client                  The AWS KMS client to use for calling the API.
  * @param[in]   request_structure       The pre-filled structure with the request data.
  * @param[out]  plaintext               The plaintext output of the call. Should be an empty, but non-null aws_byte_buf.
  * @return                              Returns AWS_OP_SUCCESS if the call succeeds and plaintext is populated.
@@ -1018,6 +1041,25 @@ int aws_kms_encrypt_blocking(
     struct aws_nitro_enclaves_kms_client *client,
     const struct aws_string *key_id,
     const struct aws_byte_buf *plaintext,
+    struct aws_byte_buf *ciphertext_blob);
+
+/**
+ * Call [AWS KMS Encrypt API](https://docs.aws.amazon.com/kms/latest/APIReference/API_Encrypt.html).
+ * This function blocks and waits for the reply.
+ *
+ * @param[in]   client              The AWS KMS client to use for calling the API.
+ * @param[in]   key_id              The ARN or alias of AWS KMS CMK used to encrypt the plaintext.
+ * @param[in]   plaintext           The plaintext to encrypt.
+ * @param[in]   encryption_context  Optional string containing a valid JSON with [Encryption context](https://docs.aws.amazon.com/kms/latest/developerguide/encrypt_context.html) to be added to the request.
+ * @param[out]  ciphertext_blob     The ciphertext blob output of the call. Should be an empty, but non-null aws_byte_buf.
+ * @return                          Returns AWS_OP_SUCCESS if the call succeeds and ciphertext_blob is populated.
+ */
+AWS_NITRO_ENCLAVES_API
+int aws_kms_encrypt_blocking_with_context(
+    struct aws_nitro_enclaves_kms_client *client,
+    const struct aws_string *key_id,
+    const struct aws_byte_buf *plaintext,
+    const struct aws_string *encryption_context,
     struct aws_byte_buf *ciphertext_blob);
 
     /**


### PR DESCRIPTION
Fixes issue: #143 

This commit adds functions `aws_kms_decrypt_blocking_with_context` and `aws_kms_encrypt_blocking_from_request` which allow users to pass a string containing the Encryption context.
