### PR TITLE
[fix] cannot build image using `containers/Dockerfile.al2`

### DIFF
--- a/containers/Dockerfile.al2
+++ b/containers/Dockerfile.al2
@@ -16,7 +16,7 @@ RUN yum install -y \
 	ninja-build \
 	doxygen
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.63
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.70
 
 # We keep the build artifacts in the -build directory
 WORKDIR /tmp/crt-builder


### PR DESCRIPTION
# What
I cannot build image using `containers/Dockerfile.al2`.
This is error log and it seems problem is rustc version.
```
 => ERROR [builder 37/48] RUN source $HOME/.cargo/env && cd aws-nitro-enclaves-nsm-api && cargo build --release --jobs $(nproc) -p nsm-lib                                                                                                                                      216.9s
------
 > [builder 37/48] RUN source $HOME/.cargo/env && cd aws-nitro-enclaves-nsm-api && cargo build --release --jobs $(nproc) -p nsm-lib:
0.672     Updating crates.io index
216.2  Downloading crates ...
216.2   Downloaded cfg-if v1.0.0
216.2   Downloaded errno v0.3.10
216.2   Downloaded cbindgen v0.24.5
216.3   Downloaded heck v0.4.1
216.3   Downloaded autocfg v1.4.0
216.3   Downloaded bitflags v2.9.0
216.3   Downloaded proc-macro2 v1.0.94
216.3   Downloaded bitflags v1.3.2
216.3   Downloaded log v0.4.26
216.3   Downloaded itoa v1.0.15
216.3   Downloaded fastrand v2.3.0
216.4   Downloaded memoffset v0.7.1
216.4   Downloaded serde_bytes v0.11.17
216.4   Downloaded pin-utils v0.1.0
216.4   Downloaded unicode-ident v1.0.18
216.4   Downloaded quote v1.0.39
216.4   Downloaded tempfile v3.18.0
216.4   Downloaded toml v0.5.11
216.4   Downloaded ryu v1.0.20
216.4   Downloaded once_cell v1.21.0
216.4   Downloaded half v1.8.3
216.4   Downloaded serde_derive v1.0.219
216.4   Downloaded serde_cbor v0.11.2
216.4   Downloaded indexmap v1.9.3
216.4   Downloaded getrandom v0.3.1
216.4   Downloaded syn v1.0.109
216.4   Downloaded serde v1.0.219
216.4   Downloaded memchr v2.7.4
216.4   Downloaded hashbrown v0.12.3
216.4   Downloaded serde_json v1.0.140
216.4   Downloaded nix v0.26.4
216.5   Downloaded syn v2.0.100
216.5   Downloaded rustix v1.0.2
216.5   Downloaded libc v0.2.170
216.6   Downloaded linux-raw-sys v0.9.2
216.7 error: package `once_cell v1.21.0` cannot be built because it requires rustc 1.70 or newer, while the currently active rustc version is 1.63.0
```

That library require 1.70, and after I changed to it, I can build image.

# Dev check
- [x] build docker image using this Dockerfile in ec2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
