### PR TITLE
Bump Rust to 1.71

### DIFF
--- a/containers/Dockerfile.al2
+++ b/containers/Dockerfile.al2
@@ -16,7 +16,7 @@ RUN yum install -y \
 	ninja-build \
 	doxygen
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.63
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.71
 
 # We keep the build artifacts in the -build directory
 WORKDIR /tmp/crt-builder


### PR DESCRIPTION
*Issue #, if available:* #153

*Description of changes:*

Update Rust version to 1.71 in order to satisfy MSRV requirements from the dependencies.
1.71 is chosen because it's the latest version currently supported in AL2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
