### PR TITLE
Fix stack exhaustion in aws_cms_cipher_decrypt()

### DIFF
--- a/source/cms.c
+++ b/source/cms.c
@@ -283,6 +283,7 @@ int aws_cms_cipher_decrypt(
         return AWS_OP_ERR;
     }
 
+    int result = AWS_OP_ERR;
     EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
     if (ctx == NULL) {
         return AWS_OP_ERR;
@@ -290,27 +291,33 @@ int aws_cms_cipher_decrypt(
 
     /* Setup the decryption context */
     if (!EVP_DecryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, key->buffer, iv->buffer)) {
-        EVP_CIPHER_CTX_free(ctx);
-        return AWS_OP_ERR;
+        goto cleanup_ctx;
     }
 
     /* Output: ciphertext_len + the block length minus one */
     int ulen, flen;
-    uint8_t out_text[ciphertext->len + EVP_CIPHER_CTX_block_size(ctx)];
+    size_t out_len = ciphertext->len + EVP_CIPHER_CTX_block_size(ctx);
+    uint8_t *out_text = aws_mem_acquire(aws_nitro_enclaves_get_allocator(), out_len);
+    if (!out_text) {
+        goto cleanup_ctx;
+    }
+
     if (!EVP_DecryptUpdate(ctx, out_text, &ulen, ciphertext->buffer, ciphertext->len) ||
         !EVP_DecryptFinal_ex(ctx, &out_text[ulen], &flen)) {
-        EVP_CIPHER_CTX_free(ctx);
-        return AWS_OP_ERR;
+        goto cleanup_out_text;
     }
 
     /* Construct the plaintext output buffer. */
     struct aws_byte_cursor cursor = aws_byte_cursor_from_array(out_text, ulen + flen);
     if (AWS_OP_SUCCESS != aws_byte_buf_init_copy_from_cursor(plaintext, aws_nitro_enclaves_get_allocator(), cursor)) {
-        EVP_CIPHER_CTX_free(ctx);
-        return AWS_OP_ERR;
+        goto cleanup_out_text;
     }
 
-    EVP_CIPHER_CTX_free(ctx);
+    result = AWS_OP_SUCCESS;
 
-    return AWS_OP_SUCCESS;
+cleanup_out_text:
+    aws_mem_release(aws_nitro_enclaves_get_allocator(), out_text);
+cleanup_ctx:
+    EVP_CIPHER_CTX_free(ctx);
+    return result;
 }

--- a/tests/kmstool-enclaves/CMakeLists.txt
+++ b/tests/kmstool-enclaves/CMakeLists.txt
@@ -49,6 +49,7 @@ add_test_case(test_basic_rest_client)
 add_test_case(test_rest_call_blocking)
 add_test_case(test_cms_parsing_correctness)
 add_test_case(test_cms_envelope_ctx_specific)
+add_test_case(test_cms_large_ciphertext)
 
 set(TEST_BINARY_NAME ${PROJECT_NAME}-tests)
 generate_test_driver(${TEST_BINARY_NAME})

--- a/tests/kmstool-enclaves/cms_test.c
+++ b/tests/kmstool-enclaves/cms_test.c
@@ -200,3 +200,40 @@ static int s_test_cms_envelope_ctx_specific(struct aws_allocator *allocator, voi
 
     return SUCCESS;
 }
+
+/* Test that large ciphertext doesn't cause stack exhaustion and is handled gracefully */
+AWS_TEST_CASE(test_cms_large_ciphertext, s_test_cms_large_ciphertext)
+static int s_test_cms_large_ciphertext(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    aws_nitro_enclaves_library_init(allocator);
+
+    /* Create a large ciphertext buffer (10MB) that would cause stack exhaustion with VLA */
+    size_t large_size = 10 * 1024 * 1024;
+    struct aws_byte_buf large_ciphertext;
+    ASSERT_SUCCESS(aws_byte_buf_init(&large_ciphertext, allocator, large_size));
+    memset(large_ciphertext.buffer, 0xAA, large_size);
+    large_ciphertext.len = large_size;
+
+    /* Create valid key and IV for AES-256-CBC */
+    struct aws_byte_buf key, iv, plaintext;
+    ASSERT_SUCCESS(aws_byte_buf_init(&key, allocator, 32));
+    memset(key.buffer, 0x00, 32);
+    key.len = 32;
+
+    ASSERT_SUCCESS(aws_byte_buf_init(&iv, allocator, 16));
+    memset(iv.buffer, 0x00, 16);
+    iv.len = 16;
+
+    /* This should fail gracefully (invalid ciphertext), but not crash from stack exhaustion */
+    int result = aws_cms_cipher_decrypt(&large_ciphertext, &key, &iv, &plaintext);
+    ASSERT_TRUE(result == AWS_OP_ERR);
+
+    aws_byte_buf_clean_up(&large_ciphertext);
+    aws_byte_buf_clean_up(&key);
+    aws_byte_buf_clean_up(&iv);
+
+    aws_nitro_enclaves_library_clean_up();
+
+    return SUCCESS;
+}


### PR DESCRIPTION
Replace variable-length array (VLA) with heap allocation to prevent stack exhaustion when processing large CMS ciphertext. The VLA allocated `ciphertext->len + block_size` bytes on the stack without bounds checking, which may cause issues with very large inputs.

### Testing

A test was added (`test_cms_large_ciphertext`) with a large CMS ciphertext that demonstrates the stack exhaustion, which passes after the fix is applied.

#### Before Fix

```
test 45
      Start 45: test_cms_large_ciphertext

45: Test command: /tmp/crt-builder/aws-nitro-enclaves-sdk-c/build/tests/kmstool-enclaves/aws-nitro-enclaves-sdk-c-tests "test_cms_large_ciphertext"
45: Test timeout computed to be: 1500
45: [INFO] [2026-02-12T15:34:54Z] [00007fe611535840] [aws-c-common] - static: libnuma.so failed to load
45: [DEBUG] [2026-02-12T15:34:54Z] [00007fe611535840] [libcrypto_resolve] - searching process and loaded modules
45: [DEBUG] [2026-02-12T15:34:54Z] [00007fe611535840] [libcrypto_resolve] - found static aws-lc HMAC symbols
45: [DEBUG] [2026-02-12T15:34:54Z] [00007fe611535840] [libcrypto_resolve] - found static aws-lc libcrypto 1.1.1 EVP_MD symbols
45: [INFO] [2026-02-12T15:34:54Z] [00007fe611535840] [tls-handler] - static: Initializing TLS using s2n.
45: [DEBUG] [2026-02-12T15:34:54Z] [00007fe611535840] [tls-handler] - ctx: Based on OS, we detected the default PKI path as /etc/ssl/certs, and ca file as /etc/pki/tls/certs/ca-bundle.crt
45/45 Test #45: test_cms_large_ciphertext ....................................***Exception: SegFault  0.04 sec

98% tests passed, 1 tests failed out of 45

Total Test time (real) =   2.38 sec

The following tests FAILED:
	 45 - test_cms_large_ciphertext (SEGFAULT)
Errors while running CTest
```

#### After Fix

```
test 45
      Start 45: test_cms_large_ciphertext

45: Test command: /tmp/crt-builder/aws-nitro-enclaves-sdk-c/build/tests/kmstool-enclaves/aws-nitro-enclaves-sdk-c-tests "test_cms_large_ciphertext"
45: Test timeout computed to be: 1500
45: [INFO] [2026-02-12T15:53:57Z] [00007f6901ea7840] [aws-c-common] - static: libnuma.so failed to load
45: [DEBUG] [2026-02-12T15:53:57Z] [00007f6901ea7840] [libcrypto_resolve] - searching process and loaded modules
45: [DEBUG] [2026-02-12T15:53:57Z] [00007f6901ea7840] [libcrypto_resolve] - found static aws-lc HMAC symbols
45: [DEBUG] [2026-02-12T15:53:57Z] [00007f6901ea7840] [libcrypto_resolve] - found static aws-lc libcrypto 1.1.1 EVP_MD symbols
45: [INFO] [2026-02-12T15:53:57Z] [00007f6901ea7840] [tls-handler] - static: Initializing TLS using s2n.
45: [DEBUG] [2026-02-12T15:53:57Z] [00007f6901ea7840] [tls-handler] - ctx: Based on OS, we detected the default PKI path as /etc/ssl/certs, and ca file as /etc/pki/tls/certs/ca-bundle.crt
45: test_cms_large_ciphertext [ OK ]
45/45 Test #45: test_cms_large_ciphertext ....................................   Passed    0.02 sec

100% tests passed, 0 tests failed out of 45
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
