### PR TITLE
cms: Reject AES-256-CBC IV with invalid length 

### DIFF
--- a/source/cms.c
+++ b/source/cms.c
@@ -186,6 +186,11 @@ int aws_cms_parse_enveloped_data(
     const uint8_t *iv_data = CBS_data(&iv_string);
     size_t iv_data_len = CBS_len(&iv_string);
 
+    /* RFC 3565 4.1: AES-IV ::= OCTET STRING (SIZE(16)) */
+    if (iv_data_len != (size_t)EVP_CIPHER_iv_length(EVP_aes_256_cbc())) {
+        goto err;
+    }
+
     cursor = aws_byte_cursor_from_array(iv_data, iv_data_len);
     if (AWS_OP_SUCCESS != aws_byte_buf_init_copy_from_cursor(iv, aws_nitro_enclaves_get_allocator(), cursor)) {
         goto err;
@@ -279,7 +284,8 @@ int aws_cms_cipher_decrypt(
     AWS_PRECONDITION(aws_byte_buf_is_valid(key));
     AWS_PRECONDITION(aws_byte_buf_is_valid(iv));
 
-    if (key->len != EVP_CIPHER_key_length(EVP_aes_256_cbc())) {
+    if (key->len != (size_t)EVP_CIPHER_key_length(EVP_aes_256_cbc()) ||
+        iv->len != (size_t)EVP_CIPHER_iv_length(EVP_aes_256_cbc())) {
         return AWS_OP_ERR;
     }
 

--- a/tests/kmstool-enclaves/CMakeLists.txt
+++ b/tests/kmstool-enclaves/CMakeLists.txt
@@ -50,6 +50,7 @@ add_test_case(test_rest_call_blocking)
 add_test_case(test_cms_parsing_correctness)
 add_test_case(test_cms_envelope_ctx_specific)
 add_test_case(test_cms_large_ciphertext)
+add_test_case(test_cms_cipher_decrypt_rejects_short_iv)
 
 set(TEST_BINARY_NAME ${PROJECT_NAME}-tests)
 generate_test_driver(${TEST_BINARY_NAME})

--- a/tests/kmstool-enclaves/cms_test.c
+++ b/tests/kmstool-enclaves/cms_test.c
@@ -7,6 +7,9 @@
 #include <aws/nitro_enclaves/nitro_enclaves.h>
 #include <aws/testing/aws_test_harness.h>
 
+#include <sys/mman.h>
+#include <unistd.h>
+
 /* CMS response from KMS. Enveloped Data. RSA-OAEP envelope with AES256-CBC encrypted content */
 static const uint8_t input_ber[] = {
     0x30, 0x80, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x07, 0x03, 0xa0, 0x80, 0x30, 0x80, 0x02, 0x01,
@@ -232,6 +235,56 @@ static int s_test_cms_large_ciphertext(struct aws_allocator *allocator, void *ct
     aws_byte_buf_clean_up(&large_ciphertext);
     aws_byte_buf_clean_up(&key);
     aws_byte_buf_clean_up(&iv);
+
+    aws_nitro_enclaves_library_clean_up();
+
+    return SUCCESS;
+}
+
+/* Test that a short IV is rejected before reaching EVP_DecryptInit_ex.
+ * AES-256-CBC requires a 16-byte IV (RFC 3565 4.1); EVP_DecryptInit_ex reads
+ * 16 bytes from the IV pointer unconditionally, so passing a shorter buffer
+ * causes a heap over-read.
+ *
+ * We place the 1-byte IV at the end of a page with a PROT_NONE guard page
+ * immediately after it, so the 16-byte over-read hits unmapped memory and
+ * causes SIGSEGV if the length check is missing. */
+
+AWS_TEST_CASE(test_cms_cipher_decrypt_rejects_short_iv, s_test_cms_cipher_decrypt_rejects_short_iv)
+static int s_test_cms_cipher_decrypt_rejects_short_iv(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    aws_nitro_enclaves_library_init(allocator);
+
+    long page_size = sysconf(_SC_PAGESIZE);
+
+    /* Map two pages: one accessible, one guard */
+    uint8_t *pages = mmap(NULL, 2 * page_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_TRUE(pages != MAP_FAILED);
+    ASSERT_SUCCESS(mprotect(pages + page_size, page_size, PROT_NONE));
+
+    /* Place 1-byte IV at the very end of the accessible page */
+    uint8_t *iv_ptr = pages + page_size - 1;
+    iv_ptr[0] = 0x00;
+
+    struct aws_byte_buf ciphertext, key, iv, plaintext;
+
+    ASSERT_SUCCESS(aws_byte_buf_init(&ciphertext, allocator, 16));
+    memset(ciphertext.buffer, 0x00, 16);
+    ciphertext.len = 16;
+
+    ASSERT_SUCCESS(aws_byte_buf_init(&key, allocator, 32));
+    memset(key.buffer, 0x00, 32);
+    key.len = 32;
+
+    iv = (struct aws_byte_buf){.len = 1, .buffer = iv_ptr, .capacity = 1, .allocator = NULL};
+
+    int result = aws_cms_cipher_decrypt(&ciphertext, &key, &iv, &plaintext);
+    ASSERT_TRUE(result == AWS_OP_ERR);
+
+    aws_byte_buf_clean_up(&ciphertext);
+    aws_byte_buf_clean_up(&key);
+    munmap(pages, 2 * page_size);
 
     aws_nitro_enclaves_library_clean_up();
 


### PR DESCRIPTION
aws_cms_parse_enveloped_data accepted an arbitrary-length IV from the CMS EnvelopedData structure without enforcing RFC 3565 section 4.1 (AES-IV ::= OCTET STRING (SIZE(16))). aws_cms_cipher_decrypt only validated key length before passing the IV buffer to EVP_DecryptInit_ex, which unconditionally reads 16 bytes regardless of actual buffer size.

Add IV length checks at both parse time and before decryption.

### Testing

With just the commit introducing the test:
```
% docker build --progress=plain -f containers/Dockerfile.al2 --target test -t aws-nitro-enclaves-sdk-c-test .
...
#54 2.884       Start 46: test_cms_cipher_decrypt_rejects_short_iv
#54 2.886 46/46 Test #46: test_cms_cipher_decrypt_rejects_short_iv .....................***Failed    0.00 sec
#54 2.887 
#54 2.887 98% tests passed, 1 tests failed out of 46
```

With the fix:
```
% docker build --progress=plain -f containers/Dockerfile.al2 --target test -t aws-nitro-enclaves-sdk-c-test .
...
#54 3.054       Start 46: test_cms_cipher_decrypt_rejects_short_iv
#54 3.057 46/46 Test #46: test_cms_cipher_decrypt_rejects_short_iv .....................   Passed    0.00 sec
#54 3.057 
#54 3.057 100% tests passed, 0 tests failed out of 
```

### Acknowledgment

Reported by @1seal.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
